### PR TITLE
added predict_probability for boosted trees

### DIFF
--- a/bigml/boostedensemble.php
+++ b/bigml/boostedensemble.php
@@ -91,6 +91,50 @@ class BoostedEnsemble extends ModelFields{
  
    }
 
+   function raw_probabilities($input_data, $by_name, $missing_strategy) {
+       //Checks and cleans input_data leaving the fields used in the model
+       $filtered_data = $this->filter_input_data($input_data, $by_name);
+
+       // Strips affixes for numeric values and casts to the final field type
+       $new_data = cast($filtered_data, $this->fields);
+
+       if ($this->regression) {
+
+           // for regression: add all the trees' predict() results. then add the initial offset
+           $total_prediction = $this->initial_offset;
+
+           foreach( $this->models as $tree ) {
+               $this_prediction = $tree->predict($new_data, null, $missing_strategy);
+               $weight = $tree->weight;
+               $total_prediction += $weight*($this_prediction->prediction);
+           }
+
+           return $total_prediction;
+   
+       } else {
+
+        // for classification: each tree has objective class, initial offsets
+
+           $total_prediction = array();
+           foreach ($this->initial_offsets as $class) {
+               $total_prediction[$class[0]] = $class[1];
+           }
+
+           foreach ( $this->models as $tree) {
+               $this_prediction = $tree->predict($new_data, null, $missing_strategy);
+
+               $objective_class = $tree->objective_class;
+               $weight = $tree->weight;
+
+               $total_prediction[$objective_class] += $weight*$this_prediction->prediction;
+           }
+
+           $softmax=$this->softmax($total_prediction);
+
+           return $softmax;
+       }
+   }
+
     function softmax($predictions) {
         // Expects predictions to be an associative array of the form
         // {"Class1" => Value1, "Class2" => Value2, ...}.
@@ -109,7 +153,7 @@ class BoostedEnsemble extends ModelFields{
         return $predictions;
     }
 
-    function predict($input_data, $by_name=true, $missing_strategy=Tree::LAST_PREDICTION, $compact=null) {
+    function predict($input_data, $by_name=true, $missing_strategy=Tree::LAST_PREDICTION) {
       /*
          Makes a prediction based on the prediction made by every model.
 
@@ -120,63 +164,48 @@ class BoostedEnsemble extends ModelFields{
          :param missing_strategy: numeric key for the individual model's
                                  prediction method. See the model predict
                                  method.
-         :param compact: If Null (as is the default), returns the just the prediction. 
-                         If False, prediction is returned as a list of maps, one
+      */                    
+
+        if ($this->regression) {
+            return $this->raw_probabilities($input_data, $by_name, $missing_strategy);
+        } else {
+            $raw_probabilities = $this->raw_probabilities($input_data, $by_name, $missing_strategy);
+            $max = max( array_values($raw_probabilities));
+            return array_search($max, $raw_probabilities);
+        }
+    }
+
+    function predict_probability($input_data, $by_name=true, $missing_strategy=Tree::LAST_PREDICTION, $compact=false) {
+      /*
+         Makes a prediction based on the prediction made by every model.
+
+         :param input_data: Test data to be used as input
+	     :param by_name: Boolean that is set to true if field_names (as
+	                     alternative to field ids) are used in the
+			             input_data dict
+         :param missing_strategy: numeric key for the individual model's
+                                 prediction method. See the model predict
+                                 method.
+         :param compact: If False, prediction is returned as a list of maps, one
                          per class, with the keys "prediction" and "probability"
                          mapped to the name of the class and it's probability,
                          respectively.  If True, returns a list of probabilities
-                         ordered by the sorted order of the class names. 
+                         ordered by the sorted order of the class names.
       */                    
 
-        //Checks and cleans input_data leaving the fields used in the model
-        $filtered_data = $this->filter_input_data($input_data, $by_name);
-
-        // Strips affixes for numeric values and casts to the final field type
-        $new_data = cast($filtered_data, $this->fields);
-
         if ($this->regression) {
+            $total_prediction = $this->raw_probabilities($input_data, $by_name, $missing_strategy);
 
-            // for regression: add all the trees' predict() results. then add the initial offset
-            $total_prediction = $this->initial_offset;
-
-            foreach( $this->models as $tree ) {
-                $this_prediction = $tree->predict($new_data, null, $missing_strategy);
-                $weight = $tree->weight;
-                $total_prediction += $weight*($this_prediction->prediction);
-            }
-
-            if (is_null($compact)) {
-                return $total_prediction;
-            } elseif ($compact) {
+            if ($compact) {
                 return array($total_prediction);
             } else {
                 return array("prediction" => $total_prediction);
             }
 
         } else {
+            $softmax = $this->raw_probabilities($input_data, $by_name, $missing_strategy);
 
-        // for classification: each tree has objective class, initial offsets
-
-            $total_prediction = array();
-            foreach ($this->initial_offsets as $class) {
-                $total_prediction[$class[0]] = $class[1];
-            }
-
-            foreach ( $this->models as $tree) {
-                $this_prediction = $tree->predict($new_data, null, $missing_strategy);
-
-                $objective_class = $tree->objective_class;
-                $weight = $tree->weight;
-
-                $total_prediction[$objective_class] += $weight*$this_prediction->prediction;
-            }
-
-            $softmax=$this->softmax($total_prediction);
-
-            if (is_null($compact)) {
-                $max = max( array_values($softmax));
-                return array_search($max, $softmax);
-            } elseif ($compact) {
+            if ($compact) {
                 return array_values($softmax);
             } else {
                 $output = array();

--- a/bigml/boostedtree.php
+++ b/bigml/boostedtree.php
@@ -103,7 +103,7 @@ class BoostedTree {
                 $path = [];
             }
             if ($missing_strategy == Tree::PROPORTIONAL) {
-                return $this->predict_proportional($input_data, $path=$path);
+                return $this->predict_proportional($input_data, $path);
             } else {
                 if ($this->children) {
                     foreach ($this->children as $child) {
@@ -118,13 +118,13 @@ class BoostedTree {
                 return new Prediction($this->output, 
                                       $path, 
                                       null, 
-                                      $distribution=null, 
-                                      $count=$this->count,
-                                      $median=null,
-                                      $distribution_unit=null,
-                                      $children=$this->children,
-                                      $d_min=null,
-                                      $d_max=null);
+                                      null, 
+                                      $this->count,
+                                      null,
+                                      null,
+                                      $this->children,
+                                      null,
+                                      null);
             }
         }
 

--- a/bigml/ensemble.php
+++ b/bigml/ensemble.php
@@ -357,7 +357,7 @@ class Ensemble {
          //                 respectively.  If True, returns a list of probabilities
          //                 ordered by the sorted order of the class names.
       if ($this->boosting) {
-          return $this->boostedensemble->predict($input_data, $by_name, $missing_strategy, $compact);
+          return $this->boostedensemble->predict_probability($input_data, $by_name, $missing_strategy, $compact);
       }
 
       if ($this->regression) {

--- a/bigml/ensemble.php
+++ b/bigml/ensemble.php
@@ -59,6 +59,7 @@ class Ensemble {
          array from models
          ensemble object
       */
+
       if ($api == null) {
          $api = new BigML(null, null, null, $storage);
       }
@@ -356,7 +357,7 @@ class Ensemble {
          //                 respectively.  If True, returns a list of probabilities
          //                 ordered by the sorted order of the class names.
       if ($this->boosting) {
-          throw new Exception("This function is not implemented for boosting yet.");
+          return $this->boostedensemble->predict($input_data, $by_name, $missing_strategy, $compact);
       }
 
       if ($this->regression) {
@@ -394,8 +395,17 @@ class Ensemble {
               $votes = new MultiVote($votes_split->predictions, $probabilities=true);
           }
 
-      $output = $votes->combine($method);
+      if ($compact) {
+           $output = $votes->combine($method);
+      } else {
+          $class_names = $this->class_names;
+          $predictions = $votes->combine($method);
 
+          $output = array();
+          foreach(range(0, count($class_names)-1) as $n) {
+              $output[] = array("prediction"=>$class_names[$n], "probability"=>$predictions[$n]);
+          }
+      }
       }
 
       return $output;


### PR DESCRIPTION
The function `predict_probability` now works for boosted trees. Also, `predict_probability` now returns the correct result for all ensembles when `$compact` is false.