### PR TITLE
Add support for Organizations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,21 +3,21 @@ BigML PHP Bindings v. 2.0
 
 **Notice: the BigML PHP bindings 2.0 may break existing code. In
 particular, all static methods have been removed from the BigML
-class. So, if you ever used the syntaxis, e.g.:
+class. So, if you ever used the syntaxis, e.g.:**
 
     BigML::create_source(...);
 
-you will get an error. On the other hand, if you followed the syntaxis
-which was documented in this README, i.e.,
+**you will get an error. On the other hand, if you followed the syntaxis
+which was documented in this README, i.e.,**
 
     $api->create_source(...)
 
-you will be fine.
+**you will be fine.
 
-Another notice that the old constructor which accepted all of its
-parameters as individual arguments has been deprecated in favour of a
-new one supporting the sprcification of named parameters. Use the new
-syntaxis instead, as described below. The old constructor syntaxis
+**Additionally, notice that the old constructor which accepted all of
+its parameters as individual arguments has been deprecated in favour
+of a new one supporting the sprcification of named parameters. Use the
+new syntaxis instead, as described below. The old constructor syntaxis
 will be maintained until version 3.0, then removed.**
 
 In this repository you'll find an open source PHP library that gives

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ which was documented in this README, i.e.,**
 
 **Additionally, notice that the old constructor which accepted all of
 its parameters as individual arguments has been deprecated in favour
-of a new one supporting the sprcification of named parameters. Use the
+of a new one supporting the specification of named parameters. Use the
 new syntaxis instead, as described below. The old constructor syntaxis
 will be maintained until version 3.0, then removed.**
 
@@ -177,8 +177,10 @@ All the requests to BigML.io must be authenticated using your username
 and `API key <https://bigml.com/account/apikey>`_. and are always
 transmitted over HTTPS.
 
-This module will look for your username and API key in the environment variables BIGML_USERNAME and BIGML_API_KEY respectively. 
-You can add the following lines to your .bashrc or .bash_profile to set those variables automatically when you log in::
+This module will look for your username and API key in the environment
+variables BIGML_USERNAME and BIGML_API_KEY respectively.  You can add
+the following lines to your .bashrc or .bash_profile to set those
+variables automatically when you log in::
 
     export BIGML_USERNAME=myusername
     export BIGML_API_KEY=a11e579e7e53fb9abd646a6ff8aa99d4afe83ac2
@@ -188,20 +190,24 @@ a breeze::
 
    $api = new BigML\BigML();
 
-You can initialize directly when instantiating the BigML
-class as follows::
+Otherwise, you can initialize directly when instantiating the BigML
+class as follows by manually supplying your credentials:
 
    $api = new BigML\BigML([ "username" => "myusername",
                             "apiKey" => "my_api_key"]);
 
+Caching
+-------
 
-NOTICE: BigML API used to provide a sandbox mode, also know as
-development mode. This has been deprecated and is not supported in the
-PHP binding anymore. To guarantee backward-compatibility, the BigML
-class constructor still supports the specification of a ``dev_mode``
-argument, but it is now ignored.
+An important feature provided by the api constructor is the
+specification of a local cache to speed up the retrieval of
+resources. If you supply a storage for your BigML instance, the PHP
+bindings will hit the network only once for each resource. On
+subsequent accesses, the resource will be retrieved from the local
+cache.
 
-Setting the storage argument in the api instantiation::
+This is how you can set the storage argument when you instantiate the
+BigML class:
 
    $api = new BigML\BigML([ "username" => "myusername",
                             "apiKey" => "my_api_key",
@@ -215,12 +221,22 @@ if you have your environment set.
 
 All resources will be created, updated, or retrieved in/from the chosen directory.
 
+Virtual Private Clouds
+----------------------
+
 For Virtual Private Cloud setups, you can change the remote server domain:
     
    $api = new BigML\BigML([ "username" => "myusername",
                             "apiKey" => "my_api_key",
                             "domain" => "my_VPC.bigml.io",
                             "storage" => "storage/data"]);
+
+NOTICE: BigML API used to provide a sandbox mode, also know as
+development mode. This has been deprecated and is not supported in the
+PHP binding anymore. To guarantee backward-compatibility, the BigML
+class constructor still supports the specification of a ``dev_mode``
+argument, but it is now ignored.
+
 
 Projects and Organizations
 --------------------------
@@ -281,7 +297,8 @@ for).
     5.7,2.5,5.0,2.0,Iris-virginica
     5.8,2.8,5.1,2.4,Iris-virginica
 
-You can easily generate a prediction following these steps::
+If your credentials are stored in the environment as mentioned above,
+you can easily generate a prediction following these steps:
 
     $api = new BigML\BigML();
 
@@ -290,7 +307,7 @@ You can easily generate a prediction following these steps::
     $model = $api->create_model($dataset);
     $prediction = $api->create_prediction($model, array('sepal length'=> 5, 'sepal width'=> 2.5));
 
-    then:
+then:
 
     $objective_field_name = $prediction->object->fields->{$prediction->object->objective_fields[0]}->name;
 
@@ -3098,7 +3115,7 @@ You can use the information returned by the API when asking for a
 cluster to create a Cluster object in your own computer that will be
 able to produce predictions with no further connection to the remote
 API. The local Cluster object can be instantiated by using the entire
-response of the GET call to the API::
+response of the GET call to the API:
 
     $cluster = $api->get_cluster("cluster/539xxxxxxxxxxxxxxxxxxxx18");
     $local_cluster = new BigML\Cluster($cluster);

--- a/README.rst
+++ b/README.rst
@@ -191,6 +191,34 @@ For Virtual Private Cloud setups, you can change the remote server domain::
     
    $api = new BigML\BigML("myusername", "my_api_key", true, 'storage/data', my_VPC.bigml.io);
 
+Projects and Organizations
+--------------------------
+
+When you instantiate the BigML class you can specify a project or
+organization that the instance shall default to:
+
+   $api = new BigML\BigML("myusername","my_api_key", true, null,
+                           null, null, null, $projectID);
+
+   $api = new BigML\BigML("myusername","my_api_key", true, null,
+                           null, null, null, null, $organizationID);
+
+When $project is set to a project ID and that project exists for an
+organization, the user is considered to be working in an organization
+project. The scope of the API requests will be limited to this project
+and permissions should be previously given by the organization
+administrator.
+
+If the specified project does not belong to an organization but is a
+project of the user's, then the scope of all API requests will be
+limited to that project.
+
+When $organization is set to an organization ID, the user is considered
+to be working for an organization. The scope of the API requests will
+be limited to the projects of the organization and permissions need to
+be previously given by the organization administrator.
+
+
 Quick Start
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,24 @@
-BigML PHP Bindings
-=====================
+BigML PHP Bindings v. 2.0
+=========================
+
+**Notice: the BigML PHP bindings 2.0 may break existing code. In
+particular, all static methods have been removed from the BigML
+class. So, if you ever used the syntaxis, e.g.:
+
+    BigML::create_source(...);
+
+you will get an error. On the other hand, if you followed the syntaxis
+which was documented in this README, i.e.,
+
+    $api->create_source(...)
+
+you will be fine.
+
+Another notice that the old constructor which accepted all of its
+parameters as individual arguments has been deprecated in favour of a
+new one supporting the sprcification of named parameters. Use the new
+syntaxis instead, as described below. The old constructor syntaxis
+will be maintained until version 3.0, then removed.**
 
 In this repository you'll find an open source PHP library that gives
 you a simple way to interact with `BigML <https://bigml.com>`_.
@@ -172,7 +191,8 @@ a breeze::
 You can initialize directly when instantiating the BigML
 class as follows::
 
-   $api = new BigML\BigML("myusername", "my_api_key");
+   $api = new BigML\BigML([ "username" => "myusername",
+                            "apiKey" => "my_api_key"]);
 
 
 NOTICE: BigML API used to provide a sandbox mode, also know as
@@ -183,13 +203,24 @@ argument, but it is now ignored.
 
 Setting the storage argument in the api instantiation::
 
-   $api = new BigML\BigML("myusername", "my_api_key", true, 'storage/data');
+   $api = new BigML\BigML([ "username" => "myusername",
+                            "apiKey" => "my_api_key",
+                            "storage" => "storage/data"]);
 
-all the generated, updated or retrieved resources will be automatically saved to the chosen directory.
+Or, more succinctly:
 
-For Virtual Private Cloud setups, you can change the remote server domain::
+   $api = new BigML\BigML(["storage" => "storage/data"]);
+
+if you have your environment set.
+
+All resources will be created, updated, or retrieved in/from the chosen directory.
+
+For Virtual Private Cloud setups, you can change the remote server domain:
     
-   $api = new BigML\BigML("myusername", "my_api_key", true, 'storage/data', my_VPC.bigml.io);
+   $api = new BigML\BigML([ "username" => "myusername",
+                            "apiKey" => "my_api_key",
+                            "domain" => "my_VPC.bigml.io",
+                            "storage" => "storage/data"]);
 
 Projects and Organizations
 --------------------------
@@ -197,11 +228,13 @@ Projects and Organizations
 When you instantiate the BigML class you can specify a project or
 organization that the instance shall default to:
 
-   $api = new BigML\BigML("myusername","my_api_key", true, null,
-                           null, null, null, $projectID);
+   $api = new BigML\BigML(["username" => "myusername",
+                            "apiKey" => "my_api_key",
+                            "project" => $projectID]);
 
-   $api = new BigML\BigML("myusername","my_api_key", true, null,
-                           null, null, null, null, $organizationID);
+   $api = new BigML\BigML(["username" => "myusername",
+                            "apiKey" => "my_api_key",
+                            "organization" => $organization]);
 
 When $project is set to a project ID and that project exists for an
 organization, the user is considered to be working in an organization
@@ -250,7 +283,7 @@ for).
 
 You can easily generate a prediction following these steps::
 
-    $api = new BigML\BigML("myusername", "my_api_key");
+    $api = new BigML\BigML();
 
     $source = $api->create_source('./tests/data/iris.csv');
     $dataset = $api->create_dataset($source);
@@ -3016,9 +3049,9 @@ You can use the information returned by the API when asking for a
 model to create a Model object in your own computer that will be able
 to produce predictions with no further connection to the remote
 API. The local Model object can be instantiated by using the entire
-response of the GET call to the API::
+response of the GET call to the API:
 
-    $api = new BigML\BigML("username", "api_key", false, 'storage');
+    $api = new BigML\BigML();
 
     $model = api->get_model('model/538XXXXXXXXXXXXXXXXXXX2');
     $local_model = new BigML\Model(model);
@@ -3157,7 +3190,7 @@ a specfic connection object for the remote retrieval, you can set it
 as second parameter::
 
      require 'vendor/autoload.php';
-     $api = new BigML(my_username, my_api_key);
+     $api = new BigML();
 
      $local_deepnet = new Deepnet('deepnet/502fdbcf15526876210042435', $api);
 
@@ -3236,7 +3269,7 @@ remote retrieval, you can set it as second parameter::
 
     require 'vendor/autoload.php';
 
-    $api = new BigML\BigML(my_username, my_api_key);
+    $api = new BigML\BigML();
     $local_topic_model = new BigML\TopicModel('topicmodel/502fdbcf15526876210042435', $api);
 
 You can also reuse a remote topic model JSON structure as previously

--- a/bigml/anomaly.php
+++ b/bigml/anomaly.php
@@ -59,12 +59,12 @@ class Anomaly extends ModelFields {
 
        if (is_string($anomaly)) {
 
-          if (!($api::_checkAnomalyId($anomaly)) ) {
+          if (!($api->_checkAnomalyId($anomaly)) ) {
              error_log("Wrong anomaly id");
              return null;
           }
 
-          $anomaly = $api::retrieve_resource($anomaly, $api::ONLY_MODEL);
+          $anomaly = $api->retrieve_resource($anomaly, BigML::ONLY_MODEL);
 
        }
 

--- a/bigml/association.php
+++ b/bigml/association.php
@@ -95,7 +95,7 @@ class Association extends ModelFields{
             error_log("Wrong association id");
             return null;
          } else {
-            $association = $api::retrieve_resource($association, BigML::ONLY_MODEL);
+            $association = $api->retrieve_resource($association, BigML::ONLY_MODEL);
          }
 
       }

--- a/bigml/association.php
+++ b/bigml/association.php
@@ -91,11 +91,11 @@ class Association extends ModelFields{
          if (file_exists($association))
          {
             $association = json_decode(file_get_contents($association));
-         } else if (!($api::_checkAssociationId($association)) ) {
+         } else if (!($api->_checkAssociationId($association)) ) {
             error_log("Wrong association id");
             return null;
          } else {
-            $association = $api::retrieve_resource($association, $api::ONLY_MODEL);
+            $association = $api::retrieve_resource($association, BigML::ONLY_MODEL);
          }
 
       }

--- a/bigml/basemodel.php
+++ b/bigml/basemodel.php
@@ -38,7 +38,7 @@ function print_importance($instance, $out=STDOUT) {
    }   
 }
 
-class BaseModel extends ModelFields{
+class BaseModel extends ModelFields {
    /*
       A lightweight wrapper of the basic model information
 
@@ -77,15 +77,15 @@ class BaseModel extends ModelFields{
          $this->resource_id = $model->resource;
       } else {
          if ($api == null) {
-             $api = new BigML(null, null, null, BigML::getStorage());
+             $api = new BigML(null, null, null);
          }
  
          if (is_string($model)) {                                
-            if (!($api::_checkModelId($model)) ) {
+            if (!($api->_checkModelId($model)) ) {
                error_log("Wrong model id");
                return null;
             }
-            $model = $api::retrieve_resource($model, $api::ONLY_MODEL);
+            $model = $api->retrieve_resource($model, BigML::ONLY_MODEL);
          } 
 
       } 

--- a/bigml/bigml.php
+++ b/bigml/bigml.php
@@ -159,15 +159,15 @@ class BigML {
 
       $this->storage = assign_dir($storage);
 
-      if ($project == null) {
+/*      if ($project == null) {
          $project = getenv("BIGML_PROJECT");
       }
-      $this->project = $project;
+*/      $this->project = $project;
 
-      if ($org == null) {
+/*      if ($org == null) {
          $org = getenv("BIGML_ORGANIZATION");
       }
-      $this->org = $org;
+*/      $this->org = $org;
    }
 
    /**

--- a/bigml/bigml.php
+++ b/bigml/bigml.php
@@ -20,69 +20,132 @@
 
 namespace BigML;
 
+require_once("utils.php");
+
+if (class_exists('BigML\BigML')) {
+   return;
+}
+
 class BigML {
+
    const BIGML_ENDPOINT = "https://bigml.io";
    const ONLY_MODEL = "only_model=true;limit=-1;"; 
    /**
-      * The BigML Access Username 
-      *
-      * @var string
-      * @access private
-      * @static
+    * The BigML Access Username 
+    *
+    * @var string
+    * @access private
     */
-   private static $__username = null;
+   private $__username = null;
    /**
-       * The BigML Access ApiKey 
-       *
-       * @var string
-       * @access private
-       * @static
-     */
-   private static $__apiKey = null;
+    * The BigML Access ApiKey 
+    *
+    * @var string
+    * @access private
+    */
+   private $__apiKey = null;
 
    /**
-       * The BigML Virual Private domain
-       *
-       * @var string
-       * @access private
-       * @static
-     */
-   private static $domain = false;
+    * The BigML Virual Private domain
+    *
+    * @var string
+    * @access private
+    */
+   private $domain = false;
 
-   private static $debug = false;
+   /**
+    * More diagnostics
+    *
+    * @var boolean
+    * @access private
+    */
+   private $debug = false;
 
-   private static $version = "andromeda";
+   /**
+    * The BigML API version
+    *
+    * @var string
+    * @access private
+    */
+   private $version = "andromeda";
 
-   private static $storage;
+   /**
+    * Local storage used for caching resources
+    *
+    * @var string
+    * @access private
+    */
+   private $storage;
+
+   /**
+    * If you need to access an organization's project for which you
+    * have been given privileges, set it here.
+    * Otherwise, you can restrict this BigML instance to only 
+    * operate on one of your projects by specifying it here.
+    *
+    * @var string
+    * @access private
+    */
+   private $project;
+
+   /**
+    * If an organization gave you access to their resources, set it here.
+    *
+    * @var string
+    * @access private
+    */
+   private $org;
 
    /*   
     * @param string $username 
     * @param string $apiKey
     * @param boolean $devMode
     * @param string $domain
+    * @param string $locale
+    * @param string $version
+    * @param string $project
+    * @param string $org
     * @return void
-   */
-   public function __construct($username=null, $apiKey=null, $devMode = false, $storage=null, $domain = null, $locale=null, $version="andromeda") {
-      
+    */
+   public function __construct($username = null,
+                               $apiKey = null,
+                               $devMode = false, /* deprecated */
+                               $storage = null,
+                               $domain = null,
+                               $locale = null,
+                               $version = "andromeda",
+                               $project = null,
+                               $org = null) {
+        
       if ($username == null) {
          $username = getenv("BIGML_USERNAME");
       }
-
+        
       if ($apiKey == null) {
          $apiKey = getenv("BIGML_API_KEY");
       }
 
       if ($username !== null && $apiKey !== null)
-         self::setAuth($username, $apiKey);
+         $this->setAuth($username, $apiKey);
 
-      self::$domain = $domain;
-      self::$version= $version;
+      $this->domain = $domain;
+      $this->version= $version;
 
       if ($locale != null) {
          setlocale(LC_ALL, $$locale);
       }
 
-      self::$storage=assign_dir($storage);
+      $this->storage = assign_dir($storage);
+
+      if ($project == null) {
+         $project = getenv("BIGML_PROJECT");
+      }
+      $this->project = $project;
+
+      if ($org == null) {
+         $org = getenv("BIGML_ORGANIZATION");
+      }
+      $this->org = $org;
    }
 
    /**
@@ -91,58 +154,66 @@ class BigML {
     * @param string $username Username
     * @param string $apiKey Api key
     * @return void
-   */
-   public static function setAuth($username, $apiKey) {
-      self::$__username = $username;
-      self::$__apiKey = $apiKey;
+    */
+   public function setAuth($username, $apiKey) {
+      $this->__username = $username;
+      $this->__apiKey = $apiKey;
    }
 
-   public static function setDebug($debug=false) {
-      self::$debug = $debug;
+   public function setDebug($debug=false) {
+      $this->debug = $debug;
    }
 
-   public static function setDevMode($devMode=false) {
-       trigger_error('Deprecated BigML::setDevMode.',
-                     E_USER_NOTICE);
+   public function setDevMode($devMode=false) {
+      trigger_error('Deprecated BigML::setDevMode.',
+                    E_USER_NOTICE);
    }
 
    /**
     * Check if BigML keys have been set
     *
     * @return boolean
-   */
-   public static function hasAuth() {
-      return (self::$__username !== null && self::$__apiKey !== null);
+    */
+   public function hasAuth() {
+      return ($this->__username !== null && $this->__apiKey !== null);
    }
 
-   public static function isDevMode() {
-       trigger_error('Deprecated BigML::isDevMode.',
-                     E_USER_NOTICE);
-       return false;
+   public function isDevMode() {
+      trigger_error('Deprecated BigML::isDevMode.',
+                    E_USER_NOTICE);
+      return false;
    }
 
-   public static function getUsername() {
-      return self::$__username;
+   public function getUsername() {
+      return $this->__username;
    }
 
-   public static function getApiKey() {
-      return self::$__apiKey;
+   public function getApiKey() {
+      return $this->__apiKey;
    }
 
-   public static function getDomain() {
-      return self::$domain;
+   public function getDomain() {
+      return $this->domain;
    }
 
-   public static function getVersion() {
-      return self::$version;
+   public function getVersion() {
+      return $this->version;
    }
 
-   public static function getStorage() {
-      return self::$storage;
+   public function getStorage() {
+      return $this->storage;
    }
 
-   public static function getDebug() {
-      return self::$debug;
+   public function getProject() {
+      return $this->project;
+   }
+
+   public function getOrganization() {
+      return $this->org;
+   }
+
+   public function getDebug() {
+      return $this->debug;
    }
    ##########################################################################
    #
@@ -151,47 +222,47 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_source($data, $options=array()) 
+   public function create_source($data, $options=array()) 
    {
       /*
-           Creates a new source
-              The source can be a local file path or a URL o stream source
+        Creates a new source
+        The source can be a local file path or a URL o stream source
           
-        */
+      */
       if (filter_var($data, FILTER_VALIDATE_URL)) {
-         return self::_create_remote_source($data, $options);
+         return $this->_create_remote_source($data, $options);
       } elseif (is_file($data)) {
-         return self::_create_local_source($data, $options);
+         return $this->_create_local_source($data, $options);
       } else {
          error_log("Wrong source file or url");
          return null;
       } 
    }
 
-   public static function get_source($sourceId, $queryString=null) 
+   public function get_source($sourceId, $queryString=null) 
    {
       /*
-       Retrieves a remote source.
+        Retrieves a remote source.
 
-       The source parameter should be a string containing the
-       source id or the dict returned by create_source.
-       As source is an evolving object that is processed
-       until it reaches the FINISHED or FAULTY state, thet function will
-       return a dict that encloses the source values and state info
-       available at the time it is called.
+        The source parameter should be a string containing the
+        source id or the dict returned by create_source.
+        As source is an evolving object that is processed
+        until it reaches the FINISHED or FAULTY state, thet function will
+        return a dict that encloses the source values and state info
+        available at the time it is called.
       */
 
-	  $rest = self::get_resource_request($sourceId, "source", "GET", $queryString);
+      $rest = $this->get_resource_request($sourceId, "source", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
    }   
 
-   public static function list_sources($queryString=null)
+   public function list_sources($queryString=null)
    {
       /*
-         Lists all your remote sources.
+        Lists all your remote sources.
       */
-      $rest = new BigMLRequest('LIST', 'source');
+      $rest = new BigMLRequest('LIST', 'source', $this);
 
       if ($queryString!=null){
          $rest->setQueryString($queryString);
@@ -200,11 +271,17 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_source($sourceId, $data, $waitTime=3000, $retries=10) {
+   public function update_source($sourceId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a source
+        Updates a source
       */
-      $rest = self::get_resource_request($sourceId, "source", "UPDATE", null, true, $waitTime, $retries);
+      $rest = $this->get_resource_request($sourceId,
+                                         "source",
+                                         "UPDATE", 
+                                         null, 
+                                         true, 
+                                         $waitTime, 
+                                         $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -214,18 +291,18 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_source($sourceId) {
+   public function delete_source($sourceId) {
       /*
-         Deletes a source
+        Deletes a source
       */
-      $rest = self::get_resource_request($sourceId, "source", "DELETE", null);
+      $rest = $this->get_resource_request($sourceId, "source", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   private static function _check_resource_status($resource, $queryString=null) 
+   private function _check_resource_status($resource, $queryString=null) 
    {
-      $rest = new BigMLRequest('GET', $resource);
+      $rest = new BigMLRequest('GET', $resource, $this);
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
       } 
@@ -238,7 +315,7 @@ class BigML {
       $obj = null;
 
       if (property_exists($item, "object")) 
-          $obj = $item->object;
+         $obj = $item->object;
 
 
       if ($obj == null)
@@ -247,18 +324,31 @@ class BigML {
       if ($obj == null)
          return false;
 
-      $status = substr( $resource, 0, 7 ) != 'project' ? $obj->status : '';
       $code = $item->code;
-      $statusCode = substr( $resource, 0, 7 ) != 'project' ? $status->code : '';
-      $message = substr( $resource, 0, 7 ) != 'project' ? $status->message : '';
-
-      return array('ready'=>$code!=null && $code==BigMLRequest::HTTP_OK && $statusCode!=null && $statusCode==BigMLRequest::FINISHED, 'code'=>$statusCode, 'message'=> $message, 'resource'=>$item);
+      if (substr( $resource, 0, 7 ) == 'project') {
+         $status = "";
+         $statusCode = "";
+         $message = "";
+      } else {
+         $status = $obj->status;
+         $statusCode = $status->code;
+         $message = $status->message;
+      }
+      $ready = $code == BigMLRequest::HTTP_OK && 
+             $statusCode == BigMLRequest::FINISHED;
+      
+      return array('ready' => $ready,
+                   'code' => $statusCode,
+                   'message' => $message,
+                   'resource' => $item);
 
    }
 
-   public static function _check_resource($resource, $queryString=null, $waitTime=3000, $retries=0)
+   public function _check_resource($resource, 
+                                   $queryString = null, 
+                                   $waitTime = 3000, 
+                                   $retries = 0)
    {
-      
       $r = $resource;
       if (is_string($resource)) 
          $r = json_decode($resource);
@@ -269,13 +359,19 @@ class BigML {
 
       if (preg_match('/(source|dataset|model|evaluation|ensemble|batchprediction|batchcentroid|prediction|cluster|centroid|anomaly|anomalyscore|sample|project|correlation|statisticaltest|association|logisticregression|library|execution|script|topicmodel|deepnet)(\/)([a-z,0-9]{24}|[a-z,0-9]{27})$/i', $resource, $result)) {
          $count = 0;
-         $status = self::_check_resource_status($resource, $queryString); 
+         $status = $this->_check_resource_status($resource, $queryString); 
          while ($count<$retries && !$status["ready"]) {
+            $waitTime = 1.1 * $waitTime;
             usleep($waitTime*1000); 
             $count++;
-            $status=self::_check_resource_status($resource, $queryString);
+            $status = $this->_check_resource_status($resource, $queryString);
          }
-         return array('type'=> strtolower($result[1]), 'id'=> $resource, 'status'=> $status["code"], 'message' => $status["message"], 'resource' => $status["resource"]);
+
+         return array('type'=> strtolower($result[1]),
+                      'id'=> $resource,
+                      'status'=> $status["code"],
+                      'message' => $status["message"],
+                      'resource' => $status["resource"]);
       }
 
       return null;
@@ -288,7 +384,7 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_dataset($origin_resource, $args=array(), $waitTime=3000, $retries=10) {
+   public function create_dataset($origin_resource, $args=array(), $waitTime=3000, $retries=10) {
       /* Uses a remote resource to create a new dataset 
        * The allowed remote resources can be:
        *   - source
@@ -301,7 +397,7 @@ class BigML {
       if (is_array($origin_resource)) {
          $datasetIds = array();
          foreach ($origin_resource as $var => $datasetId) {
-            $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+            $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
             if ($resource == null || $resource['type'] != "dataset") {
                error_log("Wrong dataset id in List");
                return null;
@@ -320,7 +416,7 @@ class BigML {
          }
 
       } else {
-         $resource = self::_check_resource($origin_resource, null, $waitTime, $retries);
+         $resource = $this->_check_resource($origin_resource, null, $waitTime, $retries);
 
          if ($resource == null || !in_array($resource['type'],array("dataset","source","cluster")) ) {
             error_log("Wrong dataset. A source, dataset, list of dataset ids or cluster id plus centroid id are needed to create a dataset");
@@ -333,12 +429,12 @@ class BigML {
          if ($resource['type'] == "cluster") {
             if (!array_key_exists("centroid",$args)) {
 
-			   $cluster = self::get_cluster($resource["id"]);
+               $cluster = $this->get_cluster($resource["id"]);
 
-			   if ( $cluster == null || !property_exists($cluster, "object") || !property_exists($cluster->object, "cluster_datasets") ) {
-                   error_log("Failed to generate the dataset. A centroid id is needed in the args argument to generate a dataset from a cluster.");
-                   return null;
-			   }
+               if ( $cluster == null || !property_exists($cluster, "object") || !property_exists($cluster->object, "cluster_datasets") ) {
+                  error_log("Failed to generate the dataset. A centroid id is needed in the args argument to generate a dataset from a cluster.");
+                  return null;
+               }
 
                $args['centroid'] = key(get_object_vars($cluster->object->cluster_datasets));
             }
@@ -349,36 +445,36 @@ class BigML {
          $args[$resource['type']] = $resource['id'];
       }
 
-      $rest = new BigMLRequest('CREATE', 'dataset');
+      $rest = new BigMLRequest('CREATE', 'dataset', $this);
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
       $rest->setHeader('Content-Length', strlen(json_encode($args)));
       return $rest->getResponse();
    }
 
-   public static function get_dataset($datasetId, $queryString=null)
+   public function get_dataset($datasetId, $queryString=null)
    {
       /*
-         Retrieves a dataset.
-         The dataset parameter should be a string containing the
-         dataset id or the dict returned by create_dataset.
-         As dataset is an evolving object that is processed
-         until it reaches the FINISHED or FAULTY state, the function will
-         return a dict that encloses the dataset values and state info
-         available at the time it is called.
-       */
+        Retrieves a dataset.
+        The dataset parameter should be a string containing the
+        dataset id or the dict returned by create_dataset.
+        As dataset is an evolving object that is processed
+        until it reaches the FINISHED or FAULTY state, the function will
+        return a dict that encloses the dataset values and state info
+        available at the time it is called.
+      */
 
-      $rest = self::get_resource_request($datasetId, "dataset", "GET", $queryString);
+      $rest = $this->get_resource_request($datasetId, "dataset", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function list_datasets($queryString=null)
+   public function list_datasets($queryString=null)
    {
-     /*
-      Lists all your datasets.
-     */
-      $rest = new BigMLRequest('LIST', 'dataset');
+      /*
+        Lists all your datasets.
+      */
+      $rest = new BigMLRequest('LIST', 'dataset', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -387,11 +483,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_dataset($datasetId, $data, $waitTime=3000, $retries=10) {
+   public function update_dataset($datasetId, $data, $waitTime=3000, $retries=10) {
       /*
         Update a dataset
       */
-      $rest = self::get_resource_request($datasetId, "dataset", "UPDATE", null, true, $waitTime, $retries);
+      $rest = $this->get_resource_request($datasetId, "dataset", "UPDATE", null, true, $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -400,21 +496,21 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_dataset($datasetId) {
+   public function delete_dataset($datasetId) {
       /*
         Delete a dataset
       */
-      $rest = self::get_resource_request($datasetId, "dataset", "DELETE", null);
+      $rest = $this->get_resource_request($datasetId, "dataset", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function download_dataset($datasetId, $filename=null){
+   public function download_dataset($datasetId, $filename=null){
       /*
-       Downloads dataset contents to a csv file or file object
+        Downloads dataset contents to a csv file or file object
       */
 
-      $rest = self::get_resource_request($datasetId, "dataset", "DOWNLOAD");
+      $rest = $this->get_resource_request($datasetId, "dataset", "DOWNLOAD");
       if ($rest == null) return null;
 
       $data = $rest->download();
@@ -431,18 +527,18 @@ class BigML {
       return $data;
    }
 
-   public static function error_counts($dataset, $raise_on_error=true, $waitTime=3000, $retries=10) {
+   public function error_counts($dataset, $raise_on_error=true, $waitTime=3000, $retries=10) {
 
       if (!is_string($dataset)) {
-        if ($dataset instanceof \STDClass && property_exists($dataset, "resource")) {
-	   $dataset = $dataset->resource;
-        } else {
-	   error_log("Wrong dataset id");
-	   return null;
-	} 
+         if ($dataset instanceof \STDClass && property_exists($dataset, "resource")) {
+            $dataset = $dataset->resource;
+         } else {
+            error_log("Wrong dataset id");
+            return null;
+         } 
       }
 
-      $resource = self::_check_resource($dataset, null, $waitTime, $retries);
+      $resource = $this->_check_resource($dataset, null, $waitTime, $retries);
 
       if ($resource == null || $resource['type'] != "dataset") {
          error_log("Wrong dataset id");
@@ -474,17 +570,17 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_logistic_regression($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
-     /* Creates a logistic regression from a `dataset`
+   public function create_logistic_regression($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
+      /* Creates a logistic regression from a `dataset`
          of a list o `datasets` */
   
-     $datasets=array();
-     if (!is_array($datasetIds)) {
+      $datasets=array();
+      if (!is_array($datasetIds)) {
          $datasetIds=array($datasetIds);
-     }
+      }
    
-     foreach ($datasetIds as $var => $datasetId) {
-         $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+      foreach ($datasetIds as $var => $datasetId) {
+         $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
          if ($resource == null || $resource['type'] != "dataset") {
             error_log("Wrong dataset id");
             return null;
@@ -495,7 +591,7 @@ class BigML {
          array_push($datasets, $resource["id"]);
       }
   
-      $rest = new BigMLRequest('CREATE', 'logisticregression');
+      $rest = new BigMLRequest('CREATE', 'logisticregression', $this);
 
       if (sizeof($datasets) > 1) {
          $data["datasets"] = $datasets;
@@ -509,30 +605,30 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_logistic_regression($logisticregression, $queryString=null, $shared_username=null,  $shared_api_key=null)
+   public function get_logistic_regression($logisticregression, $queryString=null, $shared_username=null,  $shared_api_key=null)
    {
       /*
-         Retrieves a logisticregression.
-         The logisticregression parameter should be a string containing the
-         logisticregression id or the dict returned by create_logistic_regression.
-         As model is an evolving object that is processed
-         until it reaches the FINISHED or FAULTY state, the function will
-         return a dict that encloses the model values and state info
-         available at the time it is called.
-         If this is a shared logistic regression, the username and sharing api key must
-         also be provided.
+        Retrieves a logisticregression.
+        The logisticregression parameter should be a string containing the
+        logisticregression id or the dict returned by create_logistic_regression.
+        As model is an evolving object that is processed
+        until it reaches the FINISHED or FAULTY state, the function will
+        return a dict that encloses the model values and state info
+        available at the time it is called.
+        If this is a shared logistic regression, the username and sharing api key must
+        also be provided.
       */
-      $rest = self::get_resource_request($logisticregression, "logisticregression", "GET", $queryString, true, 3000, 0, $shared_username, $shared_api_key);
+      $rest = $this->get_resource_request($logisticregression, "logisticregression", "GET", $queryString, true, 3000, 0, $shared_username, $shared_api_key);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function list_logistic_regressions($queryString=null)
+   public function list_logistic_regressions($queryString=null)
    {
       /*
-         Lists all your logistic regressions
+        Lists all your logistic regressions
       */
-      $rest = new BigMLRequest('LIST', 'logisticregression');
+      $rest = new BigMLRequest('LIST', 'logisticregression', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -541,12 +637,12 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_logistic_regression($logisticregressionId, $data, $waitTime=3000, $retries=10) {
+   public function update_logistic_regression($logisticregressionId, $data, $waitTime=3000, $retries=10) {
 
       /*
-         Updates a logistic regression 
+        Updates a logistic regression 
       */
-      $rest = self::get_resource_request($logisticregressionId, "logisticregression", "UPDATE", null, true, $waitTime, $retries);
+      $rest = $this->get_resource_request($logisticregressionId, "logisticregression", "UPDATE", null, true, $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -555,11 +651,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_logistic_regression($logisticregressionId) {
+   public function delete_logistic_regression($logisticregressionId) {
       /*
         Deletes a logistic regression 
       */
-      $rest = self::get_resource_request($logisticregressionId, "logisticregression", "DELETE", null);
+      $rest = $this->get_resource_request($logisticregressionId, "logisticregression", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -571,9 +667,9 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_model($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
+   public function create_model($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
       /*
-       Creates a model from a `dataset` or a list o `datasets`.
+        Creates a model from a `dataset` or a list o `datasets`.
       */
 
       $datasets=array();
@@ -582,7 +678,7 @@ class BigML {
       }
    
       foreach ($datasetIds as $var => $datasetId) {
-         $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+         $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
          if ($resource == null || !in_array($resource['type'], array("dataset","cluster"))) {
             error_log("Wrong dataset id");
             return null;
@@ -593,7 +689,7 @@ class BigML {
          array_push($datasets, $resource["id"]);
       }
          
-      $rest = new BigMLRequest('CREATE', 'model');
+      $rest = new BigMLRequest('CREATE', 'model', $this);
 
       if (sizeof($datasets) > 1) {
          $data["datasets"] = $datasets;   
@@ -601,17 +697,17 @@ class BigML {
 
          if ($resource['type'] == "cluster") {
             if (!array_key_exists("centroid",$data)) {
-                           $cluster = self::get_cluster($datasets[0]);
-                           if ( $cluster == null || !property_exists($cluster, "object") || !property_exists($cluster->object, "cluster_datasets") ) {
-                   error_log("Failed to generate the dataset. A centroid id is needed in the args argument to generate a dataset from a cluster.");
-                   return null;
-                           }
+               $cluster = $this->get_cluster($datasets[0]);
+               if ( $cluster == null || !property_exists($cluster, "object") || !property_exists($cluster->object, "cluster_datasets") ) {
+                  error_log("Failed to generate the dataset. A centroid id is needed in the args argument to generate a dataset from a cluster.");
+                  return null;
+               }
 
                $data['centroid'] = key(get_object_vars($cluster->object->cluster_models));
                $data["cluster"] =  $datasets[0];
             }
          } else {
-           $data["dataset"] = $datasets[0];
+            $data["dataset"] = $datasets[0];
          }
       }
 
@@ -621,30 +717,30 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_model($modelId, $queryString=null, $shared_username=null,  $shared_api_key=null)
+   public function get_model($modelId, $queryString=null, $shared_username=null,  $shared_api_key=null)
    {
       /*
-         Retrieves a model.
-         The model parameter should be a string containing the
-         model id or the dict returned by create_model.
-         As model is an evolving object that is processed
-         until it reaches the FINISHED or FAULTY state, the function will
-         return a dict that encloses the model values and state info
-         available at the time it is called.
-         If this is a shared model, the username and sharing api key must
-         also be provided.
+        Retrieves a model.
+        The model parameter should be a string containing the
+        model id or the dict returned by create_model.
+        As model is an evolving object that is processed
+        until it reaches the FINISHED or FAULTY state, the function will
+        return a dict that encloses the model values and state info
+        available at the time it is called.
+        If this is a shared model, the username and sharing api key must
+        also be provided.
       */
-      $rest = self::get_resource_request($modelId, "model", "GET", $queryString, true, 3000, 0, $shared_username, $shared_api_key);
+      $rest = $this->get_resource_request($modelId, "model", "GET", $queryString, true, 3000, 0, $shared_username, $shared_api_key);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function list_models($queryString=null)
+   public function list_models($queryString=null)
    {
       /*
-         Lists all your models
+        Lists all your models
       */
-      $rest = new BigMLRequest('LIST', 'model');
+      $rest = new BigMLRequest('LIST', 'model', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -653,12 +749,12 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_model($modelId, $data, $waitTime=3000, $retries=10) {
+   public function update_model($modelId, $data, $waitTime=3000, $retries=10) {
 
       /*
-         Updates a model
+        Updates a model
       */
-      $rest = self::get_resource_request($modelId, "model", "UPDATE", null, true, $waitTime, $retries);
+      $rest = $this->get_resource_request($modelId, "model", "UPDATE", null, true, $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -667,11 +763,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_model($modelId) {
+   public function delete_model($modelId) {
       /*
         Deletes a model
       */
-      $rest = self::get_resource_request($modelId, "model", "DELETE", null);
+      $rest = $this->get_resource_request($modelId, "model", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -683,10 +779,10 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_ensemble($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
+   public function create_ensemble($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
 
       /*
-       Creates a ensemble from a `dataset` or a list o `datasets`.
+        Creates a ensemble from a `dataset` or a list o `datasets`.
       */
 
       $datasets= array();
@@ -696,7 +792,7 @@ class BigML {
       }
 
       foreach ($datasetIds as $var => $datasetId) {
-         $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+         $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
          if ($resource == null || $resource['type'] != "dataset") {
             error_log("Wrong dataset id");
             return null;
@@ -707,7 +803,7 @@ class BigML {
          array_push($datasets, $resource["id"]);
       }
 
-      $rest = new BigMLRequest('CREATE', 'ensemble');
+      $rest = new BigMLRequest('CREATE', 'ensemble', $this);
 
       if (sizeof($datasets) > 1) {
          $data["datasets"] = $datasets;
@@ -721,30 +817,30 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_ensemble($ensembleId, $queryString=null)
+   public function get_ensemble($ensembleId, $queryString=null)
    {
       /*
-         Retrieves an ensemble.
+        Retrieves an ensemble.
 
-         The ensemble parameter should be a string containing the
-         ensemble id or the dict returned by create_ensemble.
-         As an ensemble is an evolving object that is processed
-         until it reaches the FINISHED or FAULTY state, the function will
-         return a dict that encloses the ensemble values and state info
-         available at the time it is called. 
+        The ensemble parameter should be a string containing the
+        ensemble id or the dict returned by create_ensemble.
+        As an ensemble is an evolving object that is processed
+        until it reaches the FINISHED or FAULTY state, the function will
+        return a dict that encloses the ensemble values and state info
+        available at the time it is called. 
       */
-      $rest = self::get_resource_request($ensembleId, "ensemble", "GET", $queryString);
+      $rest = $this->get_resource_request($ensembleId, "ensemble", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
 
    }
    
-   public static function list_ensembles($queryString=null)
+   public function list_ensembles($queryString=null)
    {
       /*
         Lists all your ensembles 
       */
-      $rest = new BigMLRequest('LIST', 'ensemble');
+      $rest = new BigMLRequest('LIST', 'ensemble', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -753,11 +849,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_ensemble($ensembleId, $data, $waitTime=3000, $retries=10) {
+   public function update_ensemble($ensembleId, $data, $waitTime=3000, $retries=10) {
       /*
         Updates a ensemble 
       */
-      $rest = self::get_resource_request($ensembleId, "ensemble", "UPDATE", null, true, 3000, 10);
+      $rest = $this->get_resource_request($ensembleId, "ensemble", "UPDATE", null, true, 3000, 10);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -766,11 +862,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_ensemble($ensembleId) {
+   public function delete_ensemble($ensembleId) {
       /*
         Deletes a ensemble 
       */
-      $rest = self::get_resource_request($ensembleId, "ensemble", "DELETE", null);
+      $rest = $this->get_resource_request($ensembleId, "ensemble", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -781,22 +877,22 @@ class BigML {
    # https://bigml.com/developers/predictions
    #
    ##########################################################################
-   public static function create_prediction($modelOrEnsembleId, $inputData, $args=array(), $waitTime=3000, $retries=10) {
+   public function create_prediction($modelOrEnsembleId, $inputData, $args=array(), $waitTime=3000, $retries=10) {
       /*
-         Creates a new prediction.
-         The model parameter can be:
-           - a simple model
-           - an ensemble
+        Creates a new prediction.
+        The model parameter can be:
+        - a simple model
+        - an ensemble
       */
 
-      $resource = self::_check_resource($modelOrEnsembleId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($modelOrEnsembleId, null, $waitTime, $retries);
 
       if ($resource == null || !in_array($resource['type'],array("model","ensemble", "logisticregression","deepnet")) ) {
-          error_log("Wrong model, ensemble or logistic regression id. A model, ensemble or logistic regression id is needed to create a prediction");
-          return null;
+         error_log("Wrong model, ensemble or logistic regression id. A model, ensemble or logistic regression id is needed to create a prediction");
+         return null;
       } elseif ($resource["status"] != BigMLRequest::FINISHED) {
-          error_log($resource['message']);
-          return null;
+         error_log($resource['message']);
+         return null;
       }
 
       $args = $args == null? array() : $args; 
@@ -808,7 +904,7 @@ class BigML {
 
       $args[$resource['type']] = $resource['id'];
 
-      $rest = new BigMLRequest('CREATE', 'prediction');
+      $rest = new BigMLRequest('CREATE', 'prediction', $this);
 
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
@@ -817,22 +913,22 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_prediction($predictionId, $queryString=null)
+   public function get_prediction($predictionId, $queryString=null)
    {
       /*
-         Retrieves a prediction.
+        Retrieves a prediction.
       */
-      $rest = self::get_resource_request($predictionId, "prediction", "GET", $queryString);
+      $rest = $this->get_resource_request($predictionId, "prediction", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function list_predictions($queryString=null)
+   public function list_predictions($queryString=null)
    {
       /*
-         Lists all your predictions 
+        Lists all your predictions 
       */
-      $rest = new BigMLRequest('LIST', 'prediction');
+      $rest = new BigMLRequest('LIST', 'prediction', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -841,12 +937,12 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_prediction($predictionId, $data, $waitTime=3000, $retries=10) 
+   public function update_prediction($predictionId, $data, $waitTime=3000, $retries=10) 
    {
       /*
         Updates a  prediction 
       */
-      $rest = self::get_resource_request($predictionId, "prediction", "UPDATE", null, true, $waitTime, $retries);
+      $rest = $this->get_resource_request($predictionId, "prediction", "UPDATE", null, true, $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -855,11 +951,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_prediction($predictionId) {
+   public function delete_prediction($predictionId) {
       /*
         Deletes a  prediction
       */
-      $rest = self::get_resource_request($predictionId, "prediction", "DELETE", null);
+      $rest = $this->get_resource_request($predictionId, "prediction", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -870,18 +966,18 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_batch_prediction($modelOrEnsembleId, $datasetId, $args=array(), $waitTime=3000, $retries=10) {
+   public function create_batch_prediction($modelOrEnsembleId, $datasetId, $args=array(), $waitTime=3000, $retries=10) {
 
       /*
-         Creates a new prediction.
-         The model parameter can be:
-            - a simple model
-            - an ensemble
+        Creates a new prediction.
+        The model parameter can be:
+        - a simple model
+        - an ensemble
       */
 
       $args = $args == null? array() : $args;
 
-      $resource = self::_check_resource($modelOrEnsembleId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($modelOrEnsembleId, null, $waitTime, $retries);
 
       if ($resource == null || !in_array($resource['type'],array("model","ensemble", "logisticregression")) ) {
          error_log("Wrong model , ensemble or logistic regression id. A model, ensemble or logistic regression id is needed to create a batch prediction");
@@ -893,7 +989,7 @@ class BigML {
 
       $args[$resource['type']] = $resource['id'];
 
-      $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
       if ($resource == null || $resource['type'] != "dataset" ) {
          error_log("Wrong dataset id");
          return null;
@@ -904,7 +1000,7 @@ class BigML {
 
       $args["dataset"] = $resource['id']; 
 
-      $rest = new BigMLRequest('CREATE', 'batchprediction');
+      $rest = new BigMLRequest('CREATE', 'batchprediction', $this);
 
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
@@ -912,7 +1008,7 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_batch_prediction($batchPredictionId, $queryString=null)
+   public function get_batch_prediction($batchPredictionId, $queryString=null)
    {
       /*
         Retrieves a batch prediction.
@@ -924,21 +1020,21 @@ class BigML {
         return a dict that encloses the batch_prediction values and state
         info available at the time it is called.
       */
-      $rest = self::get_resource_request($batchPredictionId, "batchprediction", "GET", $queryString);
+      $rest = $this->get_resource_request($batchPredictionId, "batchprediction", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function download_batch_prediction($batchPredictionId, $filename=null){ 
+   public function download_batch_prediction($batchPredictionId, $filename=null){ 
       /*
-         Retrieves the batch predictions file.
+        Retrieves the batch predictions file.
 
-         Downloads predictions, that are stored in a remote CSV file. If
-         a path is given in filename, the contents of the file are downloaded
-         and saved locally. A file-like object is returned otherwise.
+        Downloads predictions, that are stored in a remote CSV file. If
+        a path is given in filename, the contents of the file are downloaded
+        and saved locally. A file-like object is returned otherwise.
       */
 
-      $rest = self::get_resource_request($batchPredictionId, "batchprediction", "DOWNLOAD"); 
+      $rest = $this->get_resource_request($batchPredictionId, "batchprediction", "DOWNLOAD"); 
       if ($rest == null) return null;
 
       $data = $rest->download();
@@ -955,20 +1051,20 @@ class BigML {
       return $data;
    }
 
-   public static function source_from_batch_prediction($batchPredictionId, $args=array()) {
+   public function source_from_batch_prediction($batchPredictionId, $args=array()) {
 
-     $rest = self::get_resource_request($batchPredictionId, "batchprediction", "DOWNLOAD");
-     if ($rest == null) return null; 
-     $url = $rest->download_url();
-     return self::_create_remote_source($url, $args);
+      $rest = $this->get_resource_request($batchPredictionId, "batchprediction", "DOWNLOAD");
+      if ($rest == null) return null; 
+      $url = $rest->download_url();
+      return $this->_create_remote_source($url, $args);
    }
 
-   public static function list_batch_predictions($queryString=null)
+   public function list_batch_predictions($queryString=null)
    {
       /*
-         Lists all your batch predictions 
+        Lists all your batch predictions 
       */
-      $rest = new BigMLRequest('LIST', 'batchprediction');
+      $rest = new BigMLRequest('LIST', 'batchprediction', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -977,11 +1073,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_batch_prediction($batchPredictionId, $data, $waitTime=3000, $retries=10) {
+   public function update_batch_prediction($batchPredictionId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a batch prediction 
+        Updates a batch prediction 
       */
-      $rest = self::get_resource_request($batchPredictionId, "batchprediction", "UPDATE", null, true, $waitTime, $retries); 
+      $rest = $this->get_resource_request($batchPredictionId, "batchprediction", "UPDATE", null, true, $waitTime, $retries); 
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -990,11 +1086,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_batch_prediction($batchPredictionId) {
+   public function delete_batch_prediction($batchPredictionId) {
       /*
-         Deletes a batch prediction 
+        Deletes a batch prediction 
       */
-      $rest = self::get_resource_request($batchPredictionId, "batchprediction", "DELETE", null);
+      $rest = $this->get_resource_request($batchPredictionId, "batchprediction", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -1005,15 +1101,15 @@ class BigML {
    # https://bigml.com/developers/evaluations
    #
    ##########################################################################
-   public static function create_evaluation($modelId, $datasetId, $args=array(), $waitTime=3000, $retries=10) {
+   public function create_evaluation($modelId, $datasetId, $args=array(), $waitTime=3000, $retries=10) {
 
       /*
-         Creates a new evaluation.
+        Creates a new evaluation.
       */
 
       $args = $args == null? array() : $args;
 
-      $resource = self::_check_resource($modelId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($modelId, null, $waitTime, $retries);
 
       if ($resource == null || !in_array($resource['type'],array("model","ensemble", "logisticregression"))) {
          error_log("Wrong model, ensemble or logistic_regression id. A model,  ensemble or logistic regression id is needed to create a evaluation");
@@ -1025,7 +1121,7 @@ class BigML {
 
       $args[$resource['type']] = $resource['id'];
 
-      $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
       if ($resource == null || $resource['type'] != "dataset" ) {
          error_log("Wrong dataset id");
          return null;
@@ -1036,7 +1132,7 @@ class BigML {
 
       $args[$resource['type']] = $resource['id'];
 
-      $rest = new BigMLRequest('CREATE', 'evaluation');
+      $rest = new BigMLRequest('CREATE', 'evaluation', $this);
 
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
@@ -1044,28 +1140,28 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_evaluation($evaluationId, $queryString=null)
+   public function get_evaluation($evaluationId, $queryString=null)
    {
       /*
-         Retrieves a evaluation
-         The evaluation parameter should be a string containing the
-         evaluation id or the dict returned by create_evaluation.
-         As evaluation is an evolving object that is processed
-         until it reaches the FINISHED or FAULTY state, the function will
-         return a dict that encloses the evaluation values and state info
-         available at the time it is called. 
+        Retrieves a evaluation
+        The evaluation parameter should be a string containing the
+        evaluation id or the dict returned by create_evaluation.
+        As evaluation is an evolving object that is processed
+        until it reaches the FINISHED or FAULTY state, the function will
+        return a dict that encloses the evaluation values and state info
+        available at the time it is called. 
       */
-      $rest = self::get_resource_request($evaluationId, "evaluation", "GET", $queryString);
+      $rest = $this->get_resource_request($evaluationId, "evaluation", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function list_evaluations($queryString=null)
+   public function list_evaluations($queryString=null)
    {
       /*
         Lists all your evaluations.
       */
-      $rest = new BigMLRequest('LIST', 'evaluation');
+      $rest = new BigMLRequest('LIST', 'evaluation', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -1074,11 +1170,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_evaluation($evaluationId, $data, $waitTime=3000, $retries=10) {
+   public function update_evaluation($evaluationId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a evaluation
+        Updates a evaluation
       */
-      $rest = self::get_resource_request($evaluationId, "evaluation", "UPDATE", null, true, $waitTime, $retries);
+      $rest = $this->get_resource_request($evaluationId, "evaluation", "UPDATE", null, true, $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -1087,11 +1183,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_evaluation($evaluationId) {
+   public function delete_evaluation($evaluationId) {
       /*
-         Deletes a evaluation
+        Deletes a evaluation
       */
-      $rest = self::get_resource_request($evaluationId, "evaluation", "DELETE", null);
+      $rest = $this->get_resource_request($evaluationId, "evaluation", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -1101,9 +1197,9 @@ class BigML {
    # https://bigml.com/developers/clusters
    #
    ##########################################################################
-   public static function create_cluster($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
+   public function create_cluster($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
       /*
-         Creates a cluster from a `dataset` or a list of `datasets`
+        Creates a cluster from a `dataset` or a list of `datasets`
       */
 
       $datasets= array();
@@ -1113,7 +1209,7 @@ class BigML {
       }
 
       foreach ($datasetIds as $var => $datasetId) {
-         $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+         $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
          if ($resource == null || $resource['type'] != "dataset") {
             error_log("Wrong dataset id");
             return null;
@@ -1124,7 +1220,7 @@ class BigML {
          array_push($datasets, $resource["id"]);
       }
 
-      $rest = new BigMLRequest('CREATE', 'cluster');
+      $rest = new BigMLRequest('CREATE', 'cluster', $this);
 
       if (sizeof($datasets) > 1) {
          $data["datasets"] = $datasets;
@@ -1138,32 +1234,32 @@ class BigML {
       return $rest->getResponse();
    }
 
-    public static function get_cluster($clusterId, $queryString=null, $shared_username=null, $shared_api_key=null)
-    {
+   public function get_cluster($clusterId, $queryString=null, $shared_username=null, $shared_api_key=null)
+   {
       /*
-         Retrieves a cluster.
+        Retrieves a cluster.
 
-         The model parameter should be a string containing the
-         cluster id or the dict returned by create_cluster.
-         As cluster is an evolving object that is processed
-         until it reaches the FINISHED or FAULTY state, the function will
-         return a dict that encloses the cluster values and state info
-         available at the time it is called.
+        The model parameter should be a string containing the
+        cluster id or the dict returned by create_cluster.
+        As cluster is an evolving object that is processed
+        until it reaches the FINISHED or FAULTY state, the function will
+        return a dict that encloses the cluster values and state info
+        available at the time it is called.
 
-         If this is a shared cluster, the username and sharing api key must
-         also be provided.
+        If this is a shared cluster, the username and sharing api key must
+        also be provided.
       */
-      $rest = self::get_resource_request($clusterId, "cluster", "GET", $queryString, true, 3000, 0, $shared_username, $shared_api_key);
+      $rest = $this->get_resource_request($clusterId, "cluster", "GET", $queryString, true, 3000, 0, $shared_username, $shared_api_key);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function list_clusters($queryString=null)
+   public function list_clusters($queryString=null)
    {
       /*
-         List all your clusters
+        List all your clusters
       */
-      $rest = new BigMLRequest('LIST', 'cluster');
+      $rest = new BigMLRequest('LIST', 'cluster', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -1172,11 +1268,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_cluster($clusterId, $data, $waitTime=3000, $retries=10) {
+   public function update_cluster($clusterId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a cluster
+        Updates a cluster
       */
-      $rest = self::get_resource_request($clusterId, "cluster", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($clusterId, "cluster", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -1185,11 +1281,11 @@ class BigML {
       return $rest->getResponse();
    }      
 
-   public static function delete_cluster($clusterId) {
-   	  /*
+   public function delete_cluster($clusterId) {
+      /*
         Deletes a cluster
       */
-      $rest = self::get_resource_request($clusterId, "cluster", "DELETE", null);
+      $rest = $this->get_resource_request($clusterId, "cluster", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -1201,13 +1297,13 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_centroid($clusterId, $inputData=array(), $args=array(), $waitTime=3000, $retries=10) {
+   public function create_centroid($clusterId, $inputData=array(), $args=array(), $waitTime=3000, $retries=10) {
       /*
-         Creates a new centroid
+        Creates a new centroid
       */
       $args = $args == null? array() : $args;
 
-      $resource = self::_check_resource($clusterId);
+      $resource = $this->_check_resource($clusterId);
       if ($resource == null || $resource['type'] != "cluster") {
          error_log("Wrong cluster id");
          return null;
@@ -1219,7 +1315,7 @@ class BigML {
       $args["cluster"] = $resource["id"];
       $args["input_data"] = $inputData == null?  new \StdClass() : $inputData;
 
-      $rest = new BigMLRequest('CREATE', 'centroid');
+      $rest = new BigMLRequest('CREATE', 'centroid', $this);
 
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
@@ -1227,22 +1323,22 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_centroid($centroId, $queryString=null)
+   public function get_centroid($centroId, $queryString=null)
    {
       /*
-         Retrieves a centroid.
+        Retrieves a centroid.
       */
-      $rest = self::get_resource_request($centroId, "centroid", "GET", $queryString);
+      $rest = $this->get_resource_request($centroId, "centroid", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function list_centroids($queryString=null)
+   public function list_centroids($queryString=null)
    {
       /*
-         List all your centroids.
+        List all your centroids.
       */
-      $rest = new BigMLRequest('LIST', 'centroid');
+      $rest = new BigMLRequest('LIST', 'centroid', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -1251,11 +1347,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_centroid($centroId, $data, $waitTime=3000, $retries=10) {
+   public function update_centroid($centroId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a centroid.
+        Updates a centroid.
       */
-      $rest = self::get_resource_request($centroId, "centroid", "UPDATE",null, true, $waitTime, $retries);
+      $rest = $this->get_resource_request($centroId, "centroid", "UPDATE",null, true, $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -1264,11 +1360,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_centroid($centroId) {
+   public function delete_centroid($centroId) {
       /*  
-        Deletes a centroid.
+          Deletes a centroid.
       */
-      $rest = self::get_resource_request($centroId, "centroid", "DELETE", null);
+      $rest = $this->get_resource_request($centroId, "centroid", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -1279,13 +1375,13 @@ class BigML {
    # https://bigml.com/developers/batch_centroids
    #
    ##########################################################################
-   public static function create_batch_centroid($clusterId, $datasetId, $args=array(), $waitTime=3000, $retries=10) {
+   public function create_batch_centroid($clusterId, $datasetId, $args=array(), $waitTime=3000, $retries=10) {
       /*
-         Creates a new batch centroid.
+        Creates a new batch centroid.
       */
       $args = $args == null? array() : $args;
 
-      $resource = self::_check_resource($clusterId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($clusterId, null, $waitTime, $retries);
 
       if ($resource == null || $resource['type'] != "cluster" ) {
          error_log("Wrong cluster id");
@@ -1297,18 +1393,18 @@ class BigML {
 
       $args[$resource['type']] = $resource['id'];
 
-      $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
       if ($resource == null || $resource['type'] != "dataset" ) {
-          error_log("Wrong dataset id");
-          return null;
+         error_log("Wrong dataset id");
+         return null;
       } elseif ($resource["status"] != BigMLRequest::FINISHED) {
-          error_log($resource['message']);
-          return null;
+         error_log($resource['message']);
+         return null;
       }
 
       $args[$resource['type']] = $resource['id'];
 
-      $rest = new BigMLRequest('CREATE', 'batchcentroid');
+      $rest = new BigMLRequest('CREATE', 'batchcentroid', $this);
 
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
@@ -1317,32 +1413,32 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_batchcentroid($batchcentroId, $queryString=null)
+   public function get_batchcentroid($batchcentroId, $queryString=null)
    {
       /*
-         Retrieves a batch centroid.
+        Retrieves a batch centroid.
 
-         The batch_centroid parameter should be a string containing the
-         batch_centroid id or the dict returned by create_batch_centroid.
-         As batch_centroid is an evolving object that is processed
-         until it reaches the FINISHED or FAULTY state, the function will
-         return a dict that encloses the batch_centroid values and state
+        The batch_centroid parameter should be a string containing the
+        batch_centroid id or the dict returned by create_batch_centroid.
+        As batch_centroid is an evolving object that is processed
+        until it reaches the FINISHED or FAULTY state, the function will
+        return a dict that encloses the batch_centroid values and state
         info available at the time it is called.
       */
-      $rest = self::get_resource_request($batchcentroId, "batchcentroid", "GET", $queryString);
+      $rest = $this->get_resource_request($batchcentroId, "batchcentroid", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function download_batch_centroid($batchCentroId, $filename=null) {
+   public function download_batch_centroid($batchCentroId, $filename=null) {
       /*
-         Retrieves the batch centroid file.
+        Retrieves the batch centroid file.
 
-         Downloads centroids, that are stored in a remote CSV file. If
-         a path is given in filename, the contents of the file are downloaded
-         and saved locally. A file-like object is returned otherwise.
-   	 */
-      $rest = self::get_resource_request($batchCentroId, "batchcentroid", "DOWNLOAD");
+        Downloads centroids, that are stored in a remote CSV file. If
+        a path is given in filename, the contents of the file are downloaded
+        and saved locally. A file-like object is returned otherwise.
+      */
+      $rest = $this->get_resource_request($batchCentroId, "batchcentroid", "DOWNLOAD");
       if ($rest == null) return null;
       $data = $rest->download();
 
@@ -1359,12 +1455,12 @@ class BigML {
    }
 
 
-   public static function list_batch_centroids($queryString=null)
+   public function list_batch_centroids($queryString=null)
    {
       /*
-         Lists all your batch centroids
+        Lists all your batch centroids
       */
-      $rest = new BigMLRequest('LIST', 'batchcentroid');
+      $rest = new BigMLRequest('LIST', 'batchcentroid', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -1373,11 +1469,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_batchcentroid($batchcentroId, $data, $waitTime=3000, $retries=10) {
+   public function update_batchcentroid($batchcentroId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a batch centroid.
+        Updates a batch centroid.
       */
-      $rest = self::get_resource_request($batchcentroId, "batchcentroid", "UPDATE",null, true, $waitTime, $retries);
+      $rest = $this->get_resource_request($batchcentroId, "batchcentroid", "UPDATE",null, true, $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -1386,12 +1482,12 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_batchcentroid($batchcentroId) {
+   public function delete_batchcentroid($batchcentroId) {
       /*
-         Deletes a batch centroid.
+        Deletes a batch centroid.
       */
-      $rest = self::get_resource_request($batchcentroId, "batchcentroid", "DELETE",null);
-	  if ($rest == null) return null;
+      $rest = $this->get_resource_request($batchcentroId, "batchcentroid", "DELETE",null);
+      if ($rest == null) return null;
 
       return $rest->getResponse();
    }
@@ -1402,7 +1498,7 @@ class BigML {
    # https://bigml.com/developers/anomaly
    #
    ##########################################################################
-   public static function get_anomaly($anomalyId, $queryString=null)
+   public function get_anomaly($anomalyId, $queryString=null)
    {
       /*
         Retrieves an anomaly detector.
@@ -1416,14 +1512,14 @@ class BigML {
         If this is a shared anomaly detector, the username and sharing api
         key must also be provided.
       */
-      $rest = self::get_resource_request($anomalyId, "anomaly", "GET", $queryString);
+      $rest = $this->get_resource_request($anomalyId, "anomaly", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function create_anomaly($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
+   public function create_anomaly($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
       /*
-         Creates a anomaly from a `dataset` or a list of `datasets`
+        Creates a anomaly from a `dataset` or a list of `datasets`
       */
 
       $datasets= array();
@@ -1433,7 +1529,7 @@ class BigML {
       }
 
       foreach ($datasetIds as $var => $datasetId) {
-         $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+         $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
          if ($resource == null || $resource['type'] != "dataset") {
             error_log("Wrong dataset id");
             return null;
@@ -1444,7 +1540,7 @@ class BigML {
          array_push($datasets, $resource["id"]);
       }
 
-      $rest = new BigMLRequest('CREATE', 'anomaly');
+      $rest = new BigMLRequest('CREATE', 'anomaly', $this);
 
       if (sizeof($datasets) > 1) {
          $data["datasets"] = $datasets;
@@ -1458,12 +1554,12 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function list_anomalies($queryString=null)
+   public function list_anomalies($queryString=null)
    {
       /*
-         List all your anomalies 
+        List all your anomalies 
       */
-      $rest = new BigMLRequest('LIST', 'anomaly');
+      $rest = new BigMLRequest('LIST', 'anomaly', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -1472,11 +1568,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_anomaly($anomalyId, $data, $waitTime=3000, $retries=10) {
+   public function update_anomaly($anomalyId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a anomaly
+        Updates a anomaly
       */
-      $rest = self::get_resource_request($anomalyId, "anomaly", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($anomalyId, "anomaly", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -1485,11 +1581,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_anomaly($anomalyId) {
-          /*
+   public function delete_anomaly($anomalyId) {
+      /*
         Deletes a anomaly
       */
-      $rest = self::get_resource_request($anomalyId, "anomaly", "DELETE", null);
+      $rest = $this->get_resource_request($anomalyId, "anomaly", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -1501,23 +1597,23 @@ class BigML {
    # https://bigml.com/developers/anomalyscore
    #
    ##########################################################################
-   public static function get_anomaly_score($anomalyscoreId, $queryString=null)
+   public function get_anomaly_score($anomalyscoreId, $queryString=null)
    {
       /*
         Retrieves an anomaly score.
       */
-      $rest = self::get_resource_request($anomalyscoreId, "anomalyscore", "GET", $queryString);
+      $rest = $this->get_resource_request($anomalyscoreId, "anomalyscore", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function create_anomaly_score($anomalyId, $inputData=array(), $args=array(), $waitTime=3000, $retries=10) {
+   public function create_anomaly_score($anomalyId, $inputData=array(), $args=array(), $waitTime=3000, $retries=10) {
       /*
-         Creates a new centroid
+        Creates a new centroid
       */
       $args = $args == null? array() : $args;
 
-      $resource = self::_check_resource($anomalyId);
+      $resource = $this->_check_resource($anomalyId);
       if ($resource == null || $resource['type'] != "anomaly") {
          error_log("Wrong anomaly id");
          return null;
@@ -1529,7 +1625,7 @@ class BigML {
       $args["anomaly"] = $resource["id"];
       $args["input_data"] = $inputData == null?  new \StdClass() : $inputData;
 
-      $rest = new BigMLRequest('CREATE', 'anomalyscore');
+      $rest = new BigMLRequest('CREATE', 'anomalyscore', $this);
 
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
@@ -1537,12 +1633,12 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function list_anomaly_scores($queryString=null)
+   public function list_anomaly_scores($queryString=null)
    {
       /*
-         List all your anomalies score 
+        List all your anomalies score 
       */
-      $rest = new BigMLRequest('LIST', 'anomalyscore');
+      $rest = new BigMLRequest('LIST', 'anomalyscore', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -1551,11 +1647,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_anomaly_score($anomalyscoreId, $data, $waitTime=3000, $retries=10) {
+   public function update_anomaly_score($anomalyscoreId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a anomaly score
+        Updates a anomaly score
       */
-      $rest = self::get_resource_request($anomalyscoreId, "anomalyscore", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($anomalyscoreId, "anomalyscore", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -1564,11 +1660,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_anomaly_score($anomalyscoreId) {
-          /*
+   public function delete_anomaly_score($anomalyscoreId) {
+      /*
         Deletes a anomaly score
       */
-      $rest = self::get_resource_request($anomalyscoreId, "anomalyscore", "DELETE", null);
+      $rest = $this->get_resource_request($anomalyscoreId, "anomalyscore", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -1579,13 +1675,13 @@ class BigML {
    # https://bigml.com/developers/batch_anomalyscores
    #
    ##########################################################################
-   public static function create_batch_anomaly_score($anomalyId, $datasetId, $args=array(), $waitTime=3000, $retries=10) {
+   public function create_batch_anomaly_score($anomalyId, $datasetId, $args=array(), $waitTime=3000, $retries=10) {
       /*
-         Creates a new batch centroid.
+        Creates a new batch centroid.
       */
       $args = $args == null? array() : $args;
 
-      $resource = self::_check_resource($anomalyId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($anomalyId, null, $waitTime, $retries);
 
       if ($resource == null || $resource['type'] != "anomaly" ) {
          error_log("Wrong anomaly id");
@@ -1597,18 +1693,18 @@ class BigML {
 
       $args[$resource['type']] = $resource['id'];
 
-      $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
       if ($resource == null || $resource['type'] != "dataset" ) {
-          error_log("Wrong dataset id");
-          return null;
+         error_log("Wrong dataset id");
+         return null;
       } elseif ($resource["status"] != BigMLRequest::FINISHED) {
-          error_log($resource['message']);
-          return null;
+         error_log($resource['message']);
+         return null;
       }
 
       $args[$resource['type']] = $resource['id'];
 
-      $rest = new BigMLRequest('CREATE', 'batchanomalyscore');
+      $rest = new BigMLRequest('CREATE', 'batchanomalyscore', $this);
 
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
@@ -1617,7 +1713,7 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_batch_anomaly_score($batch_anomaly_score_Id, $queryString=null)
+   public function get_batch_anomaly_score($batch_anomaly_score_Id, $queryString=null)
    {
       /*
         Retrieves a batch anomaly score.
@@ -1630,12 +1726,12 @@ class BigML {
         return a dict that encloses the batch_anomaly_score values and state
         info available at the time it is called.
       */
-      $rest = self::get_resource_request($batch_anomaly_score_Id, "batchanomalyscore", "GET", $queryString);
+      $rest = $this->get_resource_request($batch_anomaly_score_Id, "batchanomalyscore", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function download_batch_anomaly_score($batch_anomaly_score_Id, $filename=null){
+   public function download_batch_anomaly_score($batch_anomaly_score_Id, $filename=null){
       /*
         Retrieves the batch anomaly score file.
 
@@ -1644,7 +1740,7 @@ class BigML {
         and saved locally. A file-like object is returned otherwise.
       */
 
-      $rest = self::get_resource_request($batch_anomaly_score_Id, "batchanomalyscore", "DOWNLOAD");
+      $rest = $this->get_resource_request($batch_anomaly_score_Id, "batchanomalyscore", "DOWNLOAD");
       if ($rest == null) return null;
 
       $data = $rest->download();
@@ -1661,12 +1757,12 @@ class BigML {
       return $data;
    }
 
-   public static function list_batch_anomaly_score($queryString=null)
+   public function list_batch_anomaly_score($queryString=null)
    {
       /*
-       Lists all your batch anomaly scores.
+        Lists all your batch anomaly scores.
       */
-      $rest = new BigMLRequest('LIST', 'batchanomalyscore');
+      $rest = new BigMLRequest('LIST', 'batchanomalyscore', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -1675,11 +1771,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_batch_anomaly_score($batch_anomaly_score_Id, $data, $waitTime=3000, $retries=10) {
+   public function update_batch_anomaly_score($batch_anomaly_score_Id, $data, $waitTime=3000, $retries=10) {
       /*
-       Updates a batch anomaly scores.
+        Updates a batch anomaly scores.
       */
-      $rest = self::get_resource_request($batch_anomaly_score_Id, "batchanomalyscore", "UPDATE", null, true, $waitTime, $retries);
+      $rest = $this->get_resource_request($batch_anomaly_score_Id, "batchanomalyscore", "UPDATE", null, true, $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -1688,11 +1784,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_batch_anomaly_score($batch_anomaly_score_Id) {
+   public function delete_batch_anomaly_score($batch_anomaly_score_Id) {
       /*
-         Deletes a batch prediction 
+        Deletes a batch prediction 
       */
-      $rest = self::get_resource_request($batch_anomaly_score_Id, "batchanomalyscore", "DELETE", null);
+      $rest = $this->get_resource_request($batch_anomaly_score_Id, "batchanomalyscore", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -1702,14 +1798,14 @@ class BigML {
    # Samples
    #
    ##########################################################################   
-   public static function create_sample($datasetId, $args=array(), $waitTime=3000, $retries=10) {
+   public function create_sample($datasetId, $args=array(), $waitTime=3000, $retries=10) {
       /*
-         Creates a new sample.
+        Creates a new sample.
       */
 
       $args = $args == null? array() : $args;
 
-      $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
       if ($resource == null || $resource['type'] != "dataset" ) {
          error_log("Wrong dataset id");
          return null;
@@ -1720,7 +1816,7 @@ class BigML {
 
       $args[$resource['type']] = $resource['id'];
 
-      $rest = new BigMLRequest('CREATE', 'sample');
+      $rest = new BigMLRequest('CREATE', 'sample', $this);
 
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
@@ -1728,22 +1824,22 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_sample($sampleId, $queryString=null)
+   public function get_sample($sampleId, $queryString=null)
    {
       /*
         Retrieves an sample.
       */
-      $rest = self::get_resource_request($sampleId, "sample", "GET", $queryString);
+      $rest = $this->get_resource_request($sampleId, "sample", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function list_samples($queryString=null)
+   public function list_samples($queryString=null)
    {
       /*
-       Lists all your samples.
+        Lists all your samples.
       */
-      $rest = new BigMLRequest('LIST', 'sample');
+      $rest = new BigMLRequest('LIST', 'sample', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -1752,11 +1848,11 @@ class BigML {
       return $rest->getResponse();
    }
    
-   public static function update_sample($sampleId, $data, $waitTime=3000, $retries=10) {
+   public function update_sample($sampleId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a sample 
+        Updates a sample 
       */
-      $rest = self::get_resource_request($sampleId, "sample", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($sampleId, "sample", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -1765,11 +1861,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_sample($sampleId) {
+   public function delete_sample($sampleId) {
       /*
         Deletes a sample
       */
-      $rest = self::get_resource_request($sampleId, "sample", "DELETE", null);
+      $rest = $this->get_resource_request($sampleId, "sample", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -1780,14 +1876,14 @@ class BigML {
    #
    ########################################################################## 
 
-   public static function create_project($args=array(), $waitTime=3000, $retries=10) {
+   public function create_project($args=array(), $waitTime=3000, $retries=10) {
       /*
-         Creates a project
+        Creates a project
       */
 
       $args = $args == null? array() : $args;
 
-      $rest = new BigMLRequest('CREATE', 'project');
+      $rest = new BigMLRequest('CREATE', 'project', $this);
 
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
@@ -1795,22 +1891,22 @@ class BigML {
       return $rest->getResponse();
    }
    
-   public static function get_project($projectId)
+   public function get_project($projectId)
    {
       /*
         Retrieves an project.
       */
-      $rest = self::get_resource_request($projectId, "project", "GET");
+      $rest = $this->get_resource_request($projectId, "project", "GET");
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function list_projects($queryString=null)
+   public function list_projects($queryString=null)
    {
       /*
-       Lists all your samples.
+        Lists all your samples.
       */
-      $rest = new BigMLRequest('LIST', 'project');
+      $rest = new BigMLRequest('LIST', 'project', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -1819,11 +1915,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_project($projectId, $data, $waitTime=3000, $retries=10) {
+   public function update_project($projectId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a project 
+        Updates a project 
       */
-      $rest = self::get_resource_request($projectId, "project", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($projectId, "project", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
       
       $rest->setData($data);
@@ -1832,27 +1928,27 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_project($projectId) {
+   public function delete_project($projectId) {
       /*
         Deletes a project 
       */
-      $rest = self::get_resource_request($projectId, "project", "DELETE", null);
+      $rest = $this->get_resource_request($projectId, "project", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function delete_all_project_by_name($test_name) {
-     /*
-       Delete a list from projects by name
-     */
+   public function delete_all_project_by_name($test_name) {
+      /*
+        Delete a list from projects by name
+      */
      
-     $projects = self::list_projects("name=". $test_name);
+      $projects = $this->list_projects("name=". $test_name);
 
-     if (!is_null($projects)) {
-       foreach ($projects->resources as $project) {
-          self::delete_project($project->resource);
-       }
-     }
+      if (!is_null($projects)) {
+         foreach ($projects->resources as $project) {
+            $this->delete_project($project->resource);
+         }
+      }
    }
 
    ##########################################################################
@@ -1862,12 +1958,12 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_correlation($datasetId, $data=array(), $waitTime=3000, $retries=10) {
+   public function create_correlation($datasetId, $data=array(), $waitTime=3000, $retries=10) {
       /*
-       Creates a correlation from a `dataset`.
+        Creates a correlation from a `dataset`.
       */
 
-      $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
       if ($resource == null || $resource['type'] != "dataset") {
          error_log("Wrong dataset id");
          return null;
@@ -1876,7 +1972,7 @@ class BigML {
          return null;
       }
 
-      $rest = new BigMLRequest('CREATE', 'correlation');
+      $rest = new BigMLRequest('CREATE', 'correlation', $this);
 
       $data["dataset"] = $resource["id"];
 
@@ -1886,23 +1982,23 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_correlation($correlation, $queryString=null)
+   public function get_correlation($correlation, $queryString=null)
    {
       /*
         Retrieves an correlation.
       */
-      $rest = self::get_resource_request($correlation, "correlation", "GET", $queryString);
+      $rest = $this->get_resource_request($correlation, "correlation", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
 
    }
 
-   public static function list_correlations($queryString=null)
+   public function list_correlations($queryString=null)
    {
       /*
-       Lists all your correlations.
+        Lists all your correlations.
       */
-      $rest = new BigMLRequest('LIST', 'correlation');
+      $rest = new BigMLRequest('LIST', 'correlation', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -1911,11 +2007,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_correlation($correlationId, $data, $waitTime=3000, $retries=10) {
+   public function update_correlation($correlationId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a correlation 
+        Updates a correlation 
       */
-      $rest = self::get_resource_request($correlationId, "correlation", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($correlationId, "correlation", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -1924,11 +2020,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_correlation($correlationId) {
+   public function delete_correlation($correlationId) {
       /*
         Deletes a correlation 
       */
-      $rest = self::get_resource_request($correlationId, "correlation", "DELETE", null);
+      $rest = $this->get_resource_request($correlationId, "correlation", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -1940,12 +2036,12 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_association($datasetId, $data=array(), $waitTime=3000, $retries=10) {
+   public function create_association($datasetId, $data=array(), $waitTime=3000, $retries=10) {
       /*
-       Creates a association from a `dataset`
+        Creates a association from a `dataset`
       */
 
-      $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
       if ($resource == null || $resource['type'] != "dataset") {
          error_log("Wrong dataset id");
          return null;
@@ -1954,7 +2050,7 @@ class BigML {
          return null;
       }
 
-      $rest = new BigMLRequest('CREATE', 'association');
+      $rest = new BigMLRequest('CREATE', 'association', $this);
 
       $data["dataset"] = $resource["id"];
 
@@ -1964,23 +2060,23 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_association($association, $queryString=null)
+   public function get_association($association, $queryString=null)
    {
       /*
         Retrieves an association
       */
-      $rest = self::get_resource_request($association, "association", "GET", $queryString);
+      $rest = $this->get_resource_request($association, "association", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
 
    }
 
-   public static function list_associations($queryString=null)
+   public function list_associations($queryString=null)
    {
       /*
-       Lists all your associations.
+        Lists all your associations.
       */
-      $rest = new BigMLRequest('LIST', 'association');
+      $rest = new BigMLRequest('LIST', 'association', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -1989,11 +2085,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_association($association, $data, $waitTime=3000, $retries=10) {
+   public function update_association($association, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a association 
+        Updates a association 
       */
-      $rest = self::get_resource_request($association, "association", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($association, "association", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -2002,11 +2098,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_association($association) {
+   public function delete_association($association) {
       /*
         Deletes a association
       */
-      $rest = self::get_resource_request($association, "association", "DELETE", null);
+      $rest = $this->get_resource_request($association, "association", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -2018,12 +2114,12 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_statistical_test($datasetId, $data=array(), $waitTime=3000, $retries=10) {
+   public function create_statistical_test($datasetId, $data=array(), $waitTime=3000, $retries=10) {
       /*
-       Creates a statistical test from a `dataset`
+        Creates a statistical test from a `dataset`
       */
 
-      $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+      $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
       if ($resource == null || $resource['type'] != "dataset") {
          error_log("Wrong dataset id");
          return null;
@@ -2032,7 +2128,7 @@ class BigML {
          return null;
       }
 
-      $rest = new BigMLRequest('CREATE', 'statisticaltest');
+      $rest = new BigMLRequest('CREATE', 'statisticaltest', $this);
 
       $data["dataset"] = $resource["id"];
 
@@ -2042,23 +2138,23 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_statistical_test($statisticaltest, $queryString=null)
+   public function get_statistical_test($statisticaltest, $queryString=null)
    {
       /*
         Retrieves an statistical test
       */
-      $rest = self::get_resource_request($statisticaltest, "statisticaltest", "GET", $queryString);
+      $rest = $this->get_resource_request($statisticaltest, "statisticaltest", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
 
    } 
  
-   public static function list_statistical_tests($queryString=null)
+   public function list_statistical_tests($queryString=null)
    {
       /*
-       Lists all your statistical tests.
+        Lists all your statistical tests.
       */
-      $rest = new BigMLRequest('LIST', 'statisticaltest');
+      $rest = new BigMLRequest('LIST', 'statisticaltest', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -2067,11 +2163,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_statistical_test($statisticaltest, $data, $waitTime=3000, $retries=10) {
+   public function update_statistical_test($statisticaltest, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a statistical test
+        Updates a statistical test
       */
-      $rest = self::get_resource_request($statisticaltest, "statisticaltest", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($statisticaltest, "statisticaltest", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -2080,17 +2176,17 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_statistical_test($statisticaltest) {
+   public function delete_statistical_test($statisticaltest) {
       /*
         Deletes a statistical test
       */
-      $rest = self::get_resource_request($statisticaltest, "statisticaltest", "DELETE", null);
+      $rest = $this->get_resource_request($statisticaltest, "statisticaltest", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
  
-   private static function _create_local_source($file_name, $options=array()) {
-      $rest = new BigMLRequest('CREATE', 'source');
+   private function _create_local_source($file_name, $options=array()) {
+      $rest = new BigMLRequest('CREATE', 'source', $this);
 
       if (phpversion() < 5.5) {
          $options['file'] = '@' . realpath($file_name);
@@ -2100,10 +2196,10 @@ class BigML {
 
       if ($options != null ){
          foreach ($options as $key => $value) {
-	   if (is_array($value) ){
-	     $options[$key] = json_encode($value); 
-	   }
-	 }
+            if (is_array($value) ){
+               $options[$key] = json_encode($value); 
+            }
+         }
       }
 
       $rest->setData($options, false);
@@ -2117,19 +2213,19 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_script($source_code, $args=array(), $waitTime=3000, $retries=10) {
-     /*
-       Creates a whizzml script from its source code. The `source_code`
-       parameter can be a:
-         {script ID}: the ID for an existing whizzml script
-         {string} : the string containing the source code for the script
+   public function create_script($source_code, $args=array(), $waitTime=3000, $retries=10) {
+      /*
+        Creates a whizzml script from its source code. The `source_code`
+        parameter can be a:
+        {script ID}: the ID for an existing whizzml script
+        {string} : the string containing the source code for the script
       */
       $args = $args == null? array() : $args;
       if (is_null($source_code)) {
          throw new \Exception('A valid code string or a script id must be provided.');
       }
 
-      #$resource = self::_check_resource($source_code, null, $waitTime, $retries);
+      #$resource = $this->_check_resource($source_code, null, $waitTime, $retries);
       $resource = null;
       if ($resource != null) {
          if ($resource['type'] != "script") {
@@ -2145,10 +2241,10 @@ class BigML {
       } else if (is_string($source_code)) {
          $args["source_code"] = $source_code;
       } else {
-        throw new \Exception('A valid code string or a script id must be provided.');
+         throw new \Exception('A valid code string or a script id must be provided.');
       }
 
-      $rest = new BigMLRequest('CREATE', 'script');
+      $rest = new BigMLRequest('CREATE', 'script', $this);
       $rest->setQueryString("full=false");
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
@@ -2157,29 +2253,29 @@ class BigML {
 
    }
 
-   public static function get_script($script, $queryString=null)
+   public function get_script($script, $queryString=null)
    {
       /*
-       Retrieves a script.
-       The script parameter should be a string containing the
-       script id or the dict returned by create_script.
-       As script is an evolving object that is processed
-       until it reaches the FINISHED or FAULTY state, the function will
-       return a dict that encloses the script content and state info
-       available at the time it is called.
+        Retrieves a script.
+        The script parameter should be a string containing the
+        script id or the dict returned by create_script.
+        As script is an evolving object that is processed
+        until it reaches the FINISHED or FAULTY state, the function will
+        return a dict that encloses the script content and state info
+        available at the time it is called.
       */
-      $rest = self::get_resource_request($script, "script", "GET", $queryString);
+      $rest = $this->get_resource_request($script, "script", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
 
    }
 
-   public static function list_scripts($queryString=null)
+   public function list_scripts($queryString=null)
    {
       /*
-       Lists all your scripts
+        Lists all your scripts
       */
-      $rest = new BigMLRequest('LIST', 'script');
+      $rest = new BigMLRequest('LIST', 'script', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -2188,11 +2284,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_script($script, $data, $waitTime=3000, $retries=10) {
+   public function update_script($script, $data, $waitTime=3000, $retries=10) {
       /*
-       Updates a script 
+        Updates a script 
       */
-      $rest = self::get_resource_request($script, "script", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($script, "script", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -2201,11 +2297,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_script($script) {
+   public function delete_script($script) {
       /*
-       Deletes a script
+        Deletes a script
       */
-      $rest = self::get_resource_request($script, "library", "DELETE", null);
+      $rest = $this->get_resource_request($script, "library", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -2217,7 +2313,7 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_execution($script, $args=array(), $waitTime=3000, $retries=10) {
+   public function create_execution($script, $args=array(), $waitTime=3000, $retries=10) {
       /*
         Creates a whizzml execution from a script or list of scripts 
       */
@@ -2225,32 +2321,32 @@ class BigML {
       $args = $args == null? array() : $args;
       $scriptsIds = array();
       if (is_array($script)) {
-        foreach ($script as $var => $scriptId) {
-          $resource = self::_check_resource($scriptId, null, $waitTime, $retries);
-          if ($resource == null || $resource['type'] != "script") {
-             throw new \Exception('A script id is needed to create a script execution.');
-          } elseif ($resource["status"] != BigMLRequest::FINISHED) {
-             throw new \Exception($resource['message']);
-          }
-          array_push($scriptsIds, $resource["id"]);
-        }
+         foreach ($script as $var => $scriptId) {
+            $resource = $this->_check_resource($scriptId, null, $waitTime, $retries);
+            if ($resource == null || $resource['type'] != "script") {
+               throw new \Exception('A script id is needed to create a script execution.');
+            } elseif ($resource["status"] != BigMLRequest::FINISHED) {
+               throw new \Exception($resource['message']);
+            }
+            array_push($scriptsIds, $resource["id"]);
+         }
       } else {
-        $resource = self::_check_resource($script, null, $waitTime, $retries);
-        if ($resource == null || $resource['type'] != "script") {
-          throw new \Exception('A script id is needed to create a script execution.');
-        } elseif ($resource["status"] != BigMLRequest::FINISHED) {
-          throw new \Exception($resource['message']);
-        }
-        array_push($scriptsIds, $resource["id"]);
+         $resource = $this->_check_resource($script, null, $waitTime, $retries);
+         if ($resource == null || $resource['type'] != "script") {
+            throw new \Exception('A script id is needed to create a script execution.');
+         } elseif ($resource["status"] != BigMLRequest::FINISHED) {
+            throw new \Exception($resource['message']);
+         }
+         array_push($scriptsIds, $resource["id"]);
       }
  
       if (sizeof($scriptsIds) > 1) {
-        $args["scripts"] = $scriptsIds;
+         $args["scripts"] = $scriptsIds;
       } else {
-        $args["script"] = $scriptsIds[0];
+         $args["script"] = $scriptsIds[0];
       }
     
-      $rest = new BigMLRequest('CREATE', 'execution');
+      $rest = new BigMLRequest('CREATE', 'execution', $this);
 
       $rest->setQueryString("full=false");
       $rest->setData($args);
@@ -2260,7 +2356,7 @@ class BigML {
  
    }
 
-   public static function get_execution($execution, $queryString=null)
+   public function get_execution($execution, $queryString=null)
    {
       /*
         Retrieves an execution
@@ -2271,18 +2367,18 @@ class BigML {
         return a dict that encloses the execution contents and state info
         available at the time it is called.
       */
-      $rest = self::get_resource_request($execution, "execution", "GET", $queryString);
+      $rest = $this->get_resource_request($execution, "execution", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
 
    }
 
-   public static function list_executions($queryString=null)
+   public function list_executions($queryString=null)
    {
       /*
-       Lists all your executions
+        Lists all your executions
       */
-      $rest = new BigMLRequest('LIST', 'execution');
+      $rest = new BigMLRequest('LIST', 'execution', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -2291,11 +2387,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_execution($execution, $data, $waitTime=3000, $retries=10) {
+   public function update_execution($execution, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a execution 
+        Updates a execution 
       */
-      $rest = self::get_resource_request($execution, "execution", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($execution, "execution", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -2304,11 +2400,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function delete_execution($execution) {
+   public function delete_execution($execution) {
       /*
         Deletes a execution 
       */
-      $rest = self::get_resource_request($execution, "execution", "DELETE", null);
+      $rest = $this->get_resource_request($execution, "execution", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -2320,12 +2416,12 @@ class BigML {
    #
    ##########################################################################
 
-   public static function create_library($source_code, $args=array(), $waitTime=3000, $retries=10) {
+   public function create_library($source_code, $args=array(), $waitTime=3000, $retries=10) {
       /*
         Creates a whizzml library from its source code. The `source_code`
         parameter can be a:
-           {library ID}: the ID for an existing whizzml library
-           {string} : the string containing the source code for the library
+        {library ID}: the ID for an existing whizzml library
+        {string} : the string containing the source code for the library
       */
 
       $args = $args == null? array() : $args;
@@ -2336,7 +2432,7 @@ class BigML {
       }
  
 
-      $resource = self::_check_resource($source_code, null, $waitTime, $retries);
+      $resource = $this->_check_resource($source_code, null, $waitTime, $retries);
 
       if ($resource != null) { 
          if ($resource['type'] != "library") {
@@ -2352,10 +2448,10 @@ class BigML {
       } else if (is_string($source_code)) {
          $args["source_code"] = $source_code;
       } else {
-        throw new \Exception('A valid code string or a library id must be provided.');
+         throw new \Exception('A valid code string or a library id must be provided.');
       }
 
-      $rest = new BigMLRequest('CREATE', 'library');
+      $rest = new BigMLRequest('CREATE', 'library', $this);
       $rest->setQueryString("full=false");
       $rest->setData($args);
       $rest->setHeader('Content-Type', 'application/json');
@@ -2363,7 +2459,7 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function get_library($library, $queryString=null)
+   public function get_library($library, $queryString=null)
    {
       /*
         Retrieves an library 
@@ -2374,18 +2470,18 @@ class BigML {
         return a dict that encloses the library content and state info
         available at the time it is called.
       */
-      $rest = self::get_resource_request($library, "library", "GET", $queryString);
+      $rest = $this->get_resource_request($library, "library", "GET", $queryString);
       if ($rest == null) return null;
       return $rest->getResponse();
 
    }
 
-   public static function list_libraries($queryString=null)
+   public function list_libraries($queryString=null)
    {
       /*
-       Lists all your libraries
+        Lists all your libraries
       */
-      $rest = new BigMLRequest('LIST', 'library');
+      $rest = new BigMLRequest('LIST', 'library', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -2394,11 +2490,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_library($library, $data, $waitTime=3000, $retries=10) {
+   public function update_library($library, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a library
+        Updates a library
       */
-      $rest = self::get_resource_request($library, "library", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($library, "library", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -2407,11 +2503,11 @@ class BigML {
       return $rest->getResponse();
    }
    
-   public static function delete_library($library) {
+   public function delete_library($library) {
       /*
         Deletes a library 
       */
-      $rest = self::get_resource_request($library, "library", "DELETE", null);
+      $rest = $this->get_resource_request($library, "library", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }  
@@ -2422,9 +2518,9 @@ class BigML {
    # https://bigml.com/developers/topicmodels
    #
    ##########################################################################
-   public static function create_topicmodel($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
+   public function create_topicmodel($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
       /*
-         Creates a topic model from a `dataset` or a list of `datasets`
+        Creates a topic model from a `dataset` or a list of `datasets`
       */
 
       $datasets= array();
@@ -2434,7 +2530,7 @@ class BigML {
       }
 
       foreach ($datasetIds as $var => $datasetId) {
-         $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+         $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
          if ($resource == null || $resource['type'] != "dataset") {
             error_log("Wrong dataset id");
             return null;
@@ -2445,7 +2541,7 @@ class BigML {
          array_push($datasets, $resource["id"]);
       }
 
-      $rest = new BigMLRequest('CREATE', 'topicmodel');
+      $rest = new BigMLRequest('CREATE', 'topicmodel', $this);
 
       if (sizeof($datasets) > 1) {
          $data["datasets"] = $datasets;
@@ -2459,32 +2555,32 @@ class BigML {
       return $rest->getResponse();
    }
 
-    public static function get_topicmodel($topicmodelId, $queryString=null, $shared_username=null, $shared_api_key=null)
-    {
+   public function get_topicmodel($topicmodelId, $queryString=null, $shared_username=null, $shared_api_key=null)
+   {
       /*
-         Retrieves a topic model.
+        Retrieves a topic model.
 
-         The model parameter should be a string containing the
-         topic model id or the dict returned by create_topicmodel.
-         As topic model is an evolving object that is processed
-         until it reaches the FINISHED or FAULTY state, the function will
-         return a dict that encloses the topic model values and state info
-         available at the time it is called.
+        The model parameter should be a string containing the
+        topic model id or the dict returned by create_topicmodel.
+        As topic model is an evolving object that is processed
+        until it reaches the FINISHED or FAULTY state, the function will
+        return a dict that encloses the topic model values and state info
+        available at the time it is called.
 
-         If this is a shared topic model, the username and sharing api key must
-         also be provided.
+        If this is a shared topic model, the username and sharing api key must
+        also be provided.
       */
-      $rest = self::get_resource_request($topicmodelId, "topicmodel", "GET", $queryString, true, 3000, 0, $shared_username, $shared_api_key);
+      $rest = $this->get_resource_request($topicmodelId, "topicmodel", "GET", $queryString, true, 3000, 0, $shared_username, $shared_api_key);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function list_topicmodels($queryString=null)
+   public function list_topicmodels($queryString=null)
    {
       /*
-         List all your topic models
+        List all your topic models
       */
-      $rest = new BigMLRequest('LIST', 'topicmodel');
+      $rest = new BigMLRequest('LIST', 'topicmodel', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -2493,11 +2589,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_topicmodel($topicmodelId, $data, $waitTime=3000, $retries=10) {
+   public function update_topicmodel($topicmodelId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a topic model
+        Updates a topic model
       */
-      $rest = self::get_resource_request($topicmodelId, "topicmodel", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($topicmodelId, "topicmodel", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -2506,11 +2602,11 @@ class BigML {
       return $rest->getResponse();
    }      
 
-   public static function delete_topicmodel($topicmodelId) {
-   	  /*
+   public function delete_topicmodel($topicmodelId) {
+      /*
         Deletes a topic model
       */
-      $rest = self::get_resource_request($topicmodelId, "topicmodel", "DELETE", null);
+      $rest = $this->get_resource_request($topicmodelId, "topicmodel", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
@@ -2521,9 +2617,9 @@ class BigML {
    # https://bigml.com/developers/deepnets
    #
    ##########################################################################
-   public static function create_deepnet($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
+   public function create_deepnet($datasetIds, $data=array(), $waitTime=3000, $retries=10) {
       /*
-         Creates a deepnet from a `dataset` or a list of datasets
+        Creates a deepnet from a `dataset` or a list of datasets
       */
 
       $datasets= array();
@@ -2533,7 +2629,7 @@ class BigML {
       }
 
       foreach ($datasetIds as $var => $datasetId) {
-         $resource = self::_check_resource($datasetId, null, $waitTime, $retries);
+         $resource = $this->_check_resource($datasetId, null, $waitTime, $retries);
          if ($resource == null || $resource['type'] != "dataset") {
             error_log("Wrong dataset id");
             return null;
@@ -2544,7 +2640,7 @@ class BigML {
          array_push($datasets, $resource["id"]);
       }
 
-      $rest = new BigMLRequest('CREATE', 'deepnet');
+      $rest = new BigMLRequest('CREATE', 'deepnet', $this);
 
       if (sizeof($datasets) > 1) {
          $data["datasets"] = $datasets;
@@ -2558,32 +2654,32 @@ class BigML {
       return $rest->getResponse();
    }
 
-    public static function get_deepnet($deepnetId, $queryString=null, $shared_username=null, $shared_api_key=null)
-    {
+   public function get_deepnet($deepnetId, $queryString=null, $shared_username=null, $shared_api_key=null)
+   {
       /*
-         Retrieves a deepnet.
+        Retrieves a deepnet.
 
-         The deepnetId parameter should be a string containing the
-         deepnet id or the dict returned by create_deepnet.
-         As a deepnet is an evolving object that is processed
-         until it reaches the FINISHED or FAULTY state, the function will
-         return a dict that encloses the deepnet values and state info
-         available at the time it is called.
+        The deepnetId parameter should be a string containing the
+        deepnet id or the dict returned by create_deepnet.
+        As a deepnet is an evolving object that is processed
+        until it reaches the FINISHED or FAULTY state, the function will
+        return a dict that encloses the deepnet values and state info
+        available at the time it is called.
 
-         If this is a shared deepnet, the username and sharing api key must
-         also be provided.
+        If this is a shared deepnet, the username and sharing api key must
+        also be provided.
       */
-      $rest = self::get_resource_request($deepnetId, "deepnet", "GET", $queryString, true, 3000, 0, $shared_username, $shared_api_key);
+      $rest = $this->get_resource_request($deepnetId, "deepnet", "GET", $queryString, true, 3000, 0, $shared_username, $shared_api_key);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   public static function list_deepnets($queryString=null)
+   public function list_deepnets($queryString=null)
    {
       /*
-         List all your deepnets
+        List all your deepnets
       */
-      $rest = new BigMLRequest('LIST', 'deepnet');
+      $rest = new BigMLRequest('LIST', 'deepnet', $this);
 
       if ($queryString!=null) {
          $rest->setQueryString($queryString);
@@ -2592,11 +2688,11 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function update_deepnet($deepnetId, $data, $waitTime=3000, $retries=10) {
+   public function update_deepnet($deepnetId, $data, $waitTime=3000, $retries=10) {
       /*
-         Updates a deepnet
+        Updates a deepnet
       */
-      $rest = self::get_resource_request($deepnetId, "deepnet", "UPDATE", null, true,  $waitTime, $retries);
+      $rest = $this->get_resource_request($deepnetId, "deepnet", "UPDATE", null, true,  $waitTime, $retries);
       if ($rest == null) return null;
 
       $rest->setData($data);
@@ -2605,17 +2701,17 @@ class BigML {
       return $rest->getResponse();
    }      
 
-   public static function delete_deepnet($deepnetId) {
-   	  /*
+   public function delete_deepnet($deepnetId) {
+      /*
         Deletes a deepnet
       */
-      $rest = self::get_resource_request($deepnetId, "deepnet", "DELETE", null);
+      $rest = $this->get_resource_request($deepnetId, "deepnet", "DELETE", null);
       if ($rest == null) return null;
       return $rest->getResponse();
    }
 
-   private static function _create_remote_source($file_url, $options=array()) {
-      $rest = new BigMLRequest('CREATE', 'source');
+   private function _create_remote_source($file_url, $options=array()) {
+      $rest = new BigMLRequest('CREATE', 'source', $this);
       $options['remote'] = $file_url;
       $rest->setData($options);
       $rest->setHeader('Content-Type', 'application/json');
@@ -2623,8 +2719,8 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function create_inline_source($data_string, $options=array()) {
-      $rest = new BigMLRequest('CREATE', 'source');
+   public function create_inline_source($data_string, $options=array()) {
+      $rest = new BigMLRequest('CREATE', 'source', $this);
       $options['data'] = $data_string;
       $rest->setData($options);
       $rest->setHeader('Content-Type', 'application/json');
@@ -2632,92 +2728,92 @@ class BigML {
       return $rest->getResponse();
    }
 
-   private static function _checkSourceId($stringID) {
+   private function _checkSourceId($stringID) {
       return preg_match("/^source\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
 
-   private static function _checkDatasetId($stringID) {
+   private function _checkDatasetId($stringID) {
       return preg_match("/^(public\/)?dataset\/[a-f,0-9]{24}$|^shared\/dataset\/[a-f,0-9]{27}$/i", $stringID) ? true : false;
    }
 
-   public static function _checkModelId($stringID) {
+   public function _checkModelId($stringID) {
       return preg_match("/^(public\/)?model\/[a-f,0-9]{24}$|^shared\/model\/[a-f,0-9]{27}$/i", $stringID) ? true : false;
    }
 
-   private static function _checkPredictionId($stringID) {
+   private function _checkPredictionId($stringID) {
       return preg_match("/^prediction\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
 
-   private static function _checkEvaluationId($stringID) {
+   private function _checkEvaluationId($stringID) {
       return preg_match("/^evaluation\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
 
-   public static function _checkEnsembleId($stringID) {
+   public function _checkEnsembleId($stringID) {
       return preg_match("/^ensemble\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
 
-   public static function _checkBatchPredictionId($stringID) {
+   public function _checkBatchPredictionId($stringID) {
       return preg_match("/^batchprediction\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
 
-   public static function _checkClusterId($stringID) {
+   public function _checkClusterId($stringID) {
       return preg_match("/^(public\/)?cluster\/[a-f,0-9]{24}$|^shared\/cluster\/[a-f,0-9]{27}$/i", $stringID) ? true : false;
    }
 
-   public static function _checkCentroId($stringID) {
+   public function _checkCentroId($stringID) {
       return preg_match("/^centroid\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
 
-   public static function _checkBatchCentroId($stringID) {
+   public function _checkBatchCentroId($stringID) {
       return preg_match("/^batchcentroid\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
 
-   public static function _checkAnomalyId($stringID) {
+   public function _checkAnomalyId($stringID) {
       return preg_match("/^anomaly\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
    
-   public static function _checkAssociationId($stringID) {
+   public function _checkAssociationId($stringID) {
       return preg_match("/^association\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
 
-   public static function _checkLogisticRegressionId($stringID) {
-       return preg_match("/^logisticregression\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
+   public function _checkLogisticRegressionId($stringID) {
+      return preg_match("/^logisticregression\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
 
-   public static function _checkTopicmodelId($stringID) {
+   public function _checkTopicmodelId($stringID) {
       return preg_match("/^topicmodel\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
 
-   public static function _checkDeepnetId($stringID) {
+   public function _checkDeepnetId($stringID) {
       return preg_match("/^deepnet\/[a-f,0-9]{24}$/i", $stringID) ? true : false;
    }
 
-   public static function get_fields($resource) {
+   public function get_fields($resource) {
       /*
-         Retrieve fields used by a resource.
-         Returns a dictionary with the fields that uses
-           the resource keyed by Id.
+        Retrieve fields used by a resource.
+        Returns a dictionary with the fields that uses
+        the resource keyed by Id.
       */
       $resource_id = null;
 
       if ($resource instanceof \STDClass && property_exists($resource, "resource")) {
          $resource_id = $resource->resource;
-         } else {
+      } else {
          error_log("Wrong resource object");
          return null;
       }
 
-      return self::_get_fields_key($resource, $resource_id);
+      return $this->_get_fields_key($resource, $resource_id);
 
    }
 
-   private static function _get_fields_key($resource, $resource_id) {
+   private function _get_fields_key($resource, $resource_id) {
       /*
-         Returns the fields key from a resource dict
+        Returns the fields key from a resource dict
       */
       if (in_array($resource->code, array(BigMLRequest::HTTP_OK, BigMLRequest::HTTP_ACCEPTED)) )  {
 
-         if (self::_checkModelId($resource_id)) {
+         if ($this->_checkModelId($resource_id)) {
             return $resource->object->model->model_fields;   
          } else {
             return $resource->object->fields;
@@ -2726,20 +2822,24 @@ class BigML {
       return null;
    }
 
-   public static function retrieve_resource($resource_id, $query_string=null)
+   public function retrieve_resource($resource_id, $query_string=null)
    {
       /*
-         Retrieves resource info either from a local repo or from the remote server
+        Retrieves resource info either from a local repo or from the remote server
       */
-      if (self::$storage != null) {
-         $stored_resource = self::$storage . DIRECTORY_SEPARATOR . str_replace('/','_',$resource_id);
+      if ($this->storage != null) {
+         $stored_resource = $this->storage .
+                          DIRECTORY_SEPARATOR .
+                          str_replace('/','_',$resource_id);
 
          if (file_exists($stored_resource)) {
             $resource = json_decode(file_get_contents($stored_resource));
-            if (property_exists($resource, "object") && property_exists($resource->object, "status") && $resource->object->status->code != BigMLRequest::FINISHED ) {
+            if (property_exists($resource, "object") &&
+                property_exists($resource->object, "status") &&
+                $resource->object->status->code != BigMLRequest::FINISHED ) {
                # get resource again
                try {
-                  $rest = new BigMLRequest('GET', $resource->resource);
+                  $rest = new BigMLRequest('GET', $resource->resource, $this);
                   if ($query_string!=null) {
                      $rest->setQueryString($query_string);
                   }
@@ -2752,10 +2852,10 @@ class BigML {
                return $resource;
             }
 
-          }
+         }
       }
 
-      $resource = self::_check_resource($resource_id, $query_string);
+      $resource = $this->_check_resource($resource_id, $query_string);
 
       if ($resource == null) {
          error_log("Wrong resource id");
@@ -2765,7 +2865,7 @@ class BigML {
          return null;
       }
 
-      $rest = new BigMLRequest('GET', $resource["id"]);
+      $rest = new BigMLRequest('GET', $resource["id"], $this);
 
       if ($query_string!=null) {
          $rest->setQueryString($query_string);
@@ -2774,17 +2874,17 @@ class BigML {
       return $rest->getResponse();
    }
 
-   public static function pprint($resource)
+   public function pprint($resource)
    {
       /*
-         Pretty prints a resource or part of it.
+        Pretty prints a resource or part of it.
       */
       if ($resource instanceof \STDClass && property_exists($resource, "resource") && property_exists($resource, "object")) {
 
          $resource_id = $resource->resource;
          if (preg_match('/(source|dataset|model|evaluation|ensemble|cluster)(\/)([a-f,0-9]{24}|[a-f,0-9]{27})$/i', $resource_id, $result)) {
-	    print_r($resource->object->name . "(" . $resource->object->size  . " bytes)\n");
-         } elseif (self::_checkPredictionId($resource_id)) {
+            print_r($resource->object->name . "(" . $resource->object->size  . " bytes)\n");
+         } elseif ($this->_checkPredictionId($resource_id)) {
 
             $objective_field_name = $resource->object->fields->{$resource->object->objective_fields[0]}->name;
             $input_data=array();
@@ -2796,7 +2896,7 @@ class BigML {
 
             $prediction = $resource->object->prediction->{$resource->object->objective_fields[0]};
             $str = $objective_field_name . " for " . json_encode($input_data) . " is " . $prediction . "\n";
-	    print_r($str);
+            print_r($str);
          } 
          
       } else {
@@ -2807,7 +2907,7 @@ class BigML {
 
    public function status($resourceId) {
 
-      $resource = self::_check_resource($resourceId);
+      $resource = $this->_check_resource($resourceId);
 
       if ($resource == null) {
          error_log("Wrong resource id");
@@ -2818,7 +2918,7 @@ class BigML {
 
    }
 
-   private static function check_resource_type($resourceId, $resourceType) {
+   private function check_resource_type($resourceId, $resourceType) {
       $resource = null;
       if ($resourceId instanceof \STDClass && property_exists($resourceId, "resource")) {
          $resource = $resourceId->resource;
@@ -2836,46 +2936,46 @@ class BigML {
       }
    }
 
-   private static function get_resource_request($resourceId, $resourceType, $operation, $queryString=null, $checkStatus=false, $waitTime=3000, $retries=0, $shared_username=null, $shared_api_key=null) {
+   private function get_resource_request($resourceId, $resourceType, $operation, $queryString=null, $checkStatus=false, $waitTime=3000, $retries=0, $shared_username=null, $shared_api_key=null) {
 
-     $resource=self::check_resource_type($resourceId,  $resourceType);
+      $resource=$this->check_resource_type($resourceId,  $resourceType);
 
-     if ($resource == null) {
+      if ($resource == null) {
+         error_log("Wrong ". $resourceType . " id");
+         return null;
+      }
+
+      if ($checkStatus) {
+         $resource = $this->_check_resource($resourceId, $queryString, $waitTime, $retries);
+         if ($resource["status"] != BigMLRequest::FINISHED) {
+            error_log($resource['message']);
+            return null;
+         }
+         $resource = $resource["id"];
+      }
+
+      /*if ($resource == null || $resource['type'] != $resourceType) {
         error_log("Wrong ". $resourceType . " id");
         return null;
-     }
-
-     if ($checkStatus) {
-        $resource = self::_check_resource($resourceId, $queryString, $waitTime, $retries);
-        if ($resource["status"] != BigMLRequest::FINISHED) {
-           error_log($resource['message']);
-           return null;
         }
-        $resource = $resource["id"];
-     }
 
-     /*if ($resource == null || $resource['type'] != $resourceType) {
-        error_log("Wrong ". $resourceType . " id");
-        return null;
-     }
-
-     if ($checkStatus && $resource["status"] != BigMLRequest::FINISHED) {
+        if ($checkStatus && $resource["status"] != BigMLRequest::FINISHED) {
         error_log($resource['message']);
         return null;
-     }*/
+        }*/
 
-     $rest = new BigMLRequest($operation, $resource, $shared_username, $shared_api_key);
+      $rest = new BigMLRequest($operation, $resource, $this, $shared_username, $shared_api_key);
 
-     if ($queryString!=null) {
-        $rest->setQueryString($queryString);
-     }
+      if ($queryString!=null) {
+         $rest->setQueryString($queryString);
+      }
 
-     return $rest;
+      return $rest;
    }
 
- }
+}
 
- final class BigMLRequest {
+final class BigMLRequest {
 
    # HTTP Status Codes from https://bigml.com/developers/status_codes
    const HTTP_OK = 200;
@@ -2919,30 +3019,49 @@ class BigML {
    private $data = array(); 
    private $queryString;
 
+   private $bigml;
+   
    private $response_code;
 
-   function __construct($method='GET', $uri = 'source', $shared_username=null, $shared_api_key=null) {
+   public function __construct($method = 'GET',
+                                $uri = 'source',
+                                $bigml = null,
+                                $shared_username = null,
+                                $shared_api_key = null) {
 
-      $this->endpoint=(BigML::getDomain() != null) ? BigML::getDomain() : BigML::BIGML_ENDPOINT;
+      $this->endpoint = ($bigml->getDomain() != null) ?
+                      $bigml->getDomain() : BigML::BIGML_ENDPOINT;
       $this->headers['Host'] = str_replace('https://','', $this->endpoint);
 
       $this->method = $method;
-      $this->version = BigML::getVersion();
+      $this->version = $bigml->getVersion();
       $this->uri = $uri;
 
       $this->headers['Date'] = gmdate('D, d M Y H:i:s T');
 
       if ($shared_username != null && $shared_api_key != null) {
          $this->setParameter("username", $shared_username);
-		 $this->setParameter("api_key", $shared_api_key);
-	  } else {
-        if (BigML::hasAuth()) {
-           $this->setParameter("username", BigML::getUsername());
-           $this->setParameter("api_key", BigML::getApiKey());
-        } else {
-           error_log("Cannot find BIGML AUTH");
-        }
+         $this->setParameter("api_key", $shared_api_key);
+      } else {
+         if ($bigml->hasAuth()) {
+            $this->setParameter("username", $bigml->getUsername());
+            $this->setParameter("api_key", $bigml->getApiKey());
+         } else {
+            error_log("Cannot find BIGML AUTH");
+         }
+         
+         if ($bigml == null) {
+            $bigml = new BigML();
+         }
+         $this->bigml = $bigml;
 
+         if ($bigml->getOrganization() != null) {
+            $this->setParameter("organization", $bigml->getOrganization());
+         } else {
+            if ($bigml->getProject() != null) {
+               $this->setParameter("project", $bigml->getProject());
+            }
+         }
       }
       # set download uri
       $this->uri .= ($method == "DOWNLOAD" ? '/download' : '');
@@ -2981,12 +3100,12 @@ class BigML {
          $query = substr($this->uri, -1) !== '?' ? '?' : '&';
 
          foreach ($this->parameters as $var => $value) {
-             if ($value == null || $value == '') {
-                $query .= $var.'&';
-                } else {
-                $query .= $var.'='.rawurlencode($value).'&';
-        }
-}
+            if ($value == null || $value == '') {
+               $query .= $var.'&';
+            } else {
+               $query .= $var.'='.rawurlencode($value).'&';
+            }
+         }
          $query = substr($query, 0, -1);
          $this->uri .= $query;
       }
@@ -3003,33 +3122,33 @@ class BigML {
    }
    public function download($counter=0, $retries=3, $wait_time=30) {
       try {
-        $data = file_get_contents($this->download_url());       
-        $headers = $this->parseHeaders($http_response_header);
+         $data = file_get_contents($this->download_url());       
+         $headers = $this->parseHeaders($http_response_header);
 
-        if ($headers["reponse_code"] == BigMLRequest::HTTP_OK) {
-           if ($counter < $retries) {
-             $download_status = json_decode($data);
-             if ($download_status != null && (is_object($download_status) or is_array($download_status)) ) {
-                if ($download_status->status->code != 5) {
-                  sleep($wait_time);
-                  $counter+=1;
-                  return $this->download($counter, $retries, $wait_time); 
-                } else {
-                  return $this->download($retries+1, $retries, $wait_time);
-                }
-             } 
-           } else if ($counter == $retries) {
-              error_log("The maximum number of retries for the download has been exceeded " . 
-                        "You can retry your  command again in a while.");
-           }  
+         if ($headers["reponse_code"] == BigMLRequest::HTTP_OK) {
+            if ($counter < $retries) {
+               $download_status = json_decode($data);
+               if ($download_status != null && (is_object($download_status) or is_array($download_status)) ) {
+                  if ($download_status->status->code != 5) {
+                     sleep($wait_time);
+                     $counter+=1;
+                     return $this->download($counter, $retries, $wait_time); 
+                  } else {
+                     return $this->download($retries+1, $retries, $wait_time);
+                  }
+               } 
+            } else if ($counter == $retries) {
+               error_log("The maximum number of retries for the download has been exceeded " . 
+                         "You can retry your  command again in a while.");
+            }  
 
-        } else if (in_array(intval($headers["reponse_code"]), array(BigMLRequest::HTTP_BAD_REQUEST, BigMLRequest::HTTP_UNAUTHORIZED, BigMLRequest::HTTP_NOT_FOUND, BigMLRequest::HTTP_TOO_MANY_REQUESTS))) {
+         } else if (in_array(intval($headers["reponse_code"]), array(BigMLRequest::HTTP_BAD_REQUEST, BigMLRequest::HTTP_UNAUTHORIZED, BigMLRequest::HTTP_NOT_FOUND, BigMLRequest::HTTP_TOO_MANY_REQUESTS))) {
             error_log("request error");
-        } else {
-           error_log("Unexpected exception error");
-        }
+         } else {
+            error_log("Unexpected exception error");
+         }
 
-        return $data;
+         return $data;
 
       } catch (\Exception $e) {
          error_log("Unexpected exception error");
@@ -3044,9 +3163,9 @@ class BigML {
          $query = substr($this->uri, -1) !== '?' ? '?' : '&';
          foreach ($this->parameters as $var => $value) {
             if ($value == null || $value == '') { 
-              $query .= $var.'&';
+               $query .= $var.'&';
             } else {
-              $query .= $var.'='.rawurlencode($value).'&';
+               $query .= $var.'='.rawurlencode($value).'&';
             }
          } 
          $query = substr($query, 0, -1);
@@ -3061,81 +3180,85 @@ class BigML {
       // Set Url
       $url = $this->endpoint.'/'.$this->uri;
       if (!is_null($this->version) && ($this->version != ""))
-          $url = $this->endpoint.'/'.$this->version.'/'.$this->uri;
+         $url = $this->endpoint.'/'.$this->version.'/'.$this->uri;
 
       try {
-          if (BigML::getDebug() != null && BigML::getDebug() == true)
-              echo "URL: " . $url . "\n";
+         if ($this->bigml &&
+             $this->bigml->getDebug() != null &&
+             $this->bigml->getDebug() == true)
+            echo "URL: " . $url . "\n";
           
-          $curl = curl_init();
-          curl_setopt($curl, CURLOPT_URL, $url);
+         $curl = curl_init();
+         curl_setopt($curl, CURLOPT_URL, $url);
 
-          curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-          curl_setopt($curl, CURLOPT_HEADER, true);
-          curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false );
-          curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false );
+         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+         curl_setopt($curl, CURLOPT_HEADER, true);
+         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false );
+         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false );
 
-          if ($this->method == "CREATE") {
-              curl_setopt($curl, CURLOPT_POST, true);
-              curl_setopt($curl, CURLOPT_POSTFIELDS, $this->data);
-          } elseif ($this->method == "UPDATE") {
-              curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
-              curl_setopt($curl, CURLOPT_POSTFIELDS, $this->data);
-          } elseif ($this->method == "DELETE") {
-              curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
-          } elseif ($this->method == "DOWNLOAD") { 
-              curl_setopt($curl, CURLOPT_RETURNTRANSFER, false);
-              curl_setopt($curl, CURLOPT_BINARYTRANSFER, true );
-              curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false );
-              curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10 );
-              curl_setopt($curl, CURLOPT_FILE, $this->data);
+         if ($this->method == "CREATE") {
+            curl_setopt($curl, CURLOPT_POST, true);
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $this->data);
+         } elseif ($this->method == "UPDATE") {
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $this->data);
+         } elseif ($this->method == "DELETE") {
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+         } elseif ($this->method == "DOWNLOAD") { 
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, false);
+            curl_setopt($curl, CURLOPT_BINARYTRANSFER, true );
+            curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false );
+            curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10 );
+            curl_setopt($curl, CURLOPT_FILE, $this->data);
 
-          }
-          // Set Headers
-          $headers = array();
-          foreach ($this->headers as $header => $value)
-              if (strlen($value) > 0) $headers[] = $header.': '.$value;
+         }
+         // Set Headers
+         $headers = array();
+         foreach ($this->headers as $header => $value)
+            if (strlen($value) > 0) $headers[] = $header.': '.$value;
 
-          curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
          
-          if (BigML::getDebug() != null && BigML::getDebug() == true) {
-              curl_setopt($curl, CURLOPT_VERBOSE, true);
-          }
+         if ($this->bigml &&
+             $this->bigml->getDebug() != null &&
+             $this->bigml->getDebug() == true) {
+            curl_setopt($curl, CURLOPT_VERBOSE, true);
+         }
 
-          $response = curl_exec($curl);
-          $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+         $response = curl_exec($curl);
+         $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-          if ($code == $this->response_code) {
+         if ($code == $this->response_code) {
 
-              $header_size = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
-              $header = substr($response, 0, $header_size);
-              $body = substr($response, $header_size);
+            $header_size = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
+            $header = substr($response, 0, $header_size);
+            $body = substr($response, $header_size);
 
-              $this->parseJsonResponse($body, $code, $header);
+            $this->parseJsonResponse($body, $code, $header);
 
-          } else if (in_array(intval($code), array(BigMLRequest::HTTP_BAD_REQUEST, BigMLRequest::HTTP_UNAUTHORIZED, BigMLRequest::HTTP_NOT_FOUND, BigMLRequest::HTTP_TOO_MANY_REQUESTS))) {
-              $header_size = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
-              $header = substr($response, 0, $header_size);
-              $body = substr($response, $header_size);
-              $this->response["code"] = $code; 
-              $error_message = $this->error_message(json_decode($body), $this->method);
-              $this->response["error"]["status"]["message"] = $error_message["message"];
-              $this->response["error"]["status"]["code"] = $code;
-              error_log($this->response["error"]["status"]["message"]);
-              if ($error_message["code"] != null)
-                  $this->response["error"]["status"]["code"] = $error_message["code"];
+         } else if (in_array(intval($code), array(BigMLRequest::HTTP_BAD_REQUEST, BigMLRequest::HTTP_UNAUTHORIZED, BigMLRequest::HTTP_NOT_FOUND, BigMLRequest::HTTP_TOO_MANY_REQUESTS))) {
+            $header_size = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
+            $header = substr($response, 0, $header_size);
+            $body = substr($response, $header_size);
+            $this->response["code"] = $code; 
+            $error_message = $this->error_message(json_decode($body), $this->method);
+            $this->response["error"]["status"]["message"] = $error_message["message"];
+            $this->response["error"]["status"]["code"] = $code;
+            error_log($this->response["error"]["status"]["message"]);
+            if ($error_message["code"] != null)
+               $this->response["error"]["status"]["code"] = $error_message["code"];
 
-          } else {
-              error_log("Unexpected error ". $code);
-              print_r($response);
-              $this->response["code"] = BigMLRequest::HTTP_INTERNAL_SERVER_ERROR;
-          }
+         } else {
+            error_log("Unexpected error ". $code);
+            print_r($response);
+            $this->response["code"] = BigMLRequest::HTTP_INTERNAL_SERVER_ERROR;
+         }
           
-          curl_close($curl);
+         curl_close($curl);
       } catch (\Exception $e) {
-          print("got exception");
+         print("got exception");
 
-          error_log("Unexpected exception error"); 
+         error_log("Unexpected exception error"); 
       }
 
       return json_decode( json_encode($this->response));
@@ -3157,20 +3280,22 @@ class BigML {
 
          $headers = explode("\n", $headers);
          foreach($headers as $header) {
-             if (stripos($header, 'Location:') !== false) {
+            if (stripos($header, 'Location:') !== false) {
                $cad = explode("Location:", $header);
                $this->response["location"] =trim($cad[1]);
-	       $location = $this->response["location"];
+               $location = $this->response["location"];
                break;
-             }
+            }
          }
 
          $this->response["code"] = $code;
          $this->response["resource"] = $r["resource"];
          $this->response["error"] = null;
          $this->response["object"] = $r;
-
-         maybe_save($this->response, BigML::getStorage(), $code, $location);
+         
+         if ($this->bigml) {
+            maybe_save($this->response, $this->bigml->getStorage(), $code, $location);
+         }
       }
    }
 
@@ -3214,7 +3339,7 @@ class BigML {
 
    private function error_message($resource, $method, $resource_type='resource') {
       /*
-         Error message for each type of resource
+        Error message for each type of resource
       */
       $error = null;
       $error_info = null;
@@ -3244,34 +3369,38 @@ class BigML {
                   $error = $error . ":"; 
                   $error_response["code"] = $extra->error;
                   foreach(get_object_vars($extra) as $key => $value) {
-                      $error = $error . $key . ": " . json_encode($value) . " ";
+                     $error = $error . $key . ": " . json_encode($value) . " ";
                   }
                   $error = $error . "\n"; 
                } else {
-                 $error = $error . ": " . $extra[0];
+                  $error = $error . ": " . $extra[0];
                }
             }
          }
 
          if ($code == BigMLRequest::HTTP_NOT_FOUND && strtolower($method) == 'get') {
             $alternate_message = '';
-            if (BigML::getDomain() != null && BigML::getDomain()!= BigML::BIGML_ENDPOINT) {
-               $alternate_message = "The " . $resource_type . " was not created in " . BigML::getDomain() . "\n"; 
+            if ($this->bigml &&
+                $this->bigml->getDomain() != null &&
+                $this->bigml->getDomain()!= BigML::BIGML_ENDPOINT) {
+               $alternate_message = "The " . $resource_type .
+                                  " was not created in " .
+                                  $this->bigml->getDomain() . "\n"; 
             }   
 
             $error = $error . "\nCouldn\'t find a " . $resource_type . " matching the given id. The most probable causes are:\n\n" . $alternate_message . " A typo in the " . $resource_type . "'s id.\n The " . $resource_type . " id cannot be accessed with your credentials.\n \nDouble-check your " . $resource_type . " and credentials info and retry."; 
 
          } elseif ($code == BigMLRequest::HTTP_UNAUTHORIZED) {
-            $error = $error. '\nDouble-check your credentials, and the general  domain your account is registered with (currently using '. BigML::getDomain() . '), please.';
+            $error = $error. '\nDouble-check your credentials, and the general  domain your account is registered with (currently using '. $this->bigml->getDomain() . '), please.';
          } elseif ($code == BigMLRequest::HTTP_BAD_REQUEST) { 
-             $error = $error.'\nDouble-check the arguments for the call, please.';
+            $error = $error.'\nDouble-check the arguments for the call, please.';
          } elseif ($code == BigMLRequest::HTTP_TOO_MANY_REQUESTS) {
             $error = $error.'\nToo many requests. Please stop requests for a while before resuming.';   
          } elseif ($code == BigMLRequest::HTTP_PAYMENT_REQUIRED) {
             $error = $error.'\nYou\'ll need to buy some more credits to perform the chosen action';
          }
 
-		 $error_response["message"] = $error;
+         $error_response["message"] = $error;
          return $error_response;
       }
 
@@ -3285,72 +3414,19 @@ class BigML {
       $head = array();
       foreach( $headers as $k=>$v )
       {
-        $t = explode( ':', $v, 2 );
-        if( isset( $t[1] ) )
+         $t = explode( ':', $v, 2 );
+         if( isset( $t[1] ) )
             $head[ trim($t[0]) ] = trim( $t[1] );
-        else
-        {
+         else
+         {
             $head[] = $v;
             if( preg_match( "#HTTP/[0-9\.]+\s+([0-9]+)#",$v, $out ) )
-                $head['reponse_code'] = intval($out[1]);
-        }
+               $head['reponse_code'] = intval($out[1]);
+         }
       }
       return $head;
    }
 
-}
-
-function assign_dir($path) {
-   /*
-      Silently checks the path for existence or creates it.
-       Returns either the path or Null.
-   */
-   if ($path == null || !is_string($path)) {
-      return null;
-   }
-      
-   return check_dir($path);
-}
-
-function check_dir($path) {
-   /*
-      Creates a directory if it doesn't exist
-   */
-   if (file_exists($path)){
-      if (!is_dir($path)) {
-         throw new \Exception("The given path is not a directory");
-      }
-   } elseif (count($path) > 0) {
-      if(!mkdir($path, 0777, true)) {
-         throw new \Exception("Cannot create a directory");
-      }   
-   }
-   return $path;
-}
-
-function maybe_save($resource, $path, $code, $location)
-{
-   /*
-      Builds the resource dict response and saves it if a path is provided.
-      The resource is saved in a local repo json file in the given path
-   */
-   if ($path != null &&  $resource["resource"] != null) {
-      $resource_file_name = $path . DIRECTORY_SEPARATOR . str_replace('/','_',$resource["resource"]);
-
-      $fp = fopen($resource_file_name, 'w');
-      fwrite($fp, json_encode($resource));
-      fclose($fp);
-
-     }
-}
-
-function compareFiles($file_a, $file_b)
-{
-   if (filesize($file_a) == filesize($file_b) && 
-       md5_file($file_a) == md5_file($file_b) ) {
-      return true;
-   }
-   return false;
 }
 
 ?>

--- a/bigml/bigml.php
+++ b/bigml/bigml.php
@@ -116,7 +116,29 @@ class BigML {
                                $version = "andromeda",
                                $project = null,
                                $org = null) {
-        
+      
+      if (is_array($username)) {
+         $options = $username;
+         if (array_key_exists("username", $options))
+            $username = $options["username"];
+         else
+            $username = null;
+         if (array_key_exists("apiKey", $options))
+            $apiKey = $options["apiKey"];
+         if (array_key_exists("storage", $options))
+            $storage = $options["storage"];
+         if (array_key_exists("domain", $options))
+            $domain = $options["domain"];
+         if (array_key_exists("locale", $options))
+            $locale = $options["locale"];
+         if (array_key_exists("version", $options))
+            $version = $options["version"];
+         if (array_key_exists("project", $options))
+            $project = $options["project"];
+         if (array_key_exists("organization", $options))
+            $org = $options["organization"];
+      }
+
       if ($username == null) {
          $username = getenv("BIGML_USERNAME");
       }

--- a/bigml/boostedensemble.php
+++ b/bigml/boostedensemble.php
@@ -47,11 +47,11 @@ class BoostedEnsemble extends ModelFields{
       $this->ensemble_id = null;
       $models = array();
 
-      if (is_string($ensemble) && $api != null && $api::_checkEnsembleId($ensemble)) {
-            $ensemble = $api::get_ensemble($ensemble);
+      if (is_string($ensemble) && $api != null && $api->_checkEnsembleId($ensemble)) {
+            $ensemble = $api->get_ensemble($ensemble);
       }
 
-      if ($ensemble instanceof \STDClass && property_exists($ensemble, "resource") && $api::_checkEnsembleId($ensemble->resource) && $ensemble->object->status->code == 5) {
+      if ($ensemble instanceof \STDClass && property_exists($ensemble, "resource") && $api->_checkEnsembleId($ensemble->resource) && $ensemble->object->status->code == 5) {
 
           parent::__construct($ensemble->object->ensemble->fields);
  
@@ -85,7 +85,7 @@ class BoostedEnsemble extends ModelFields{
             if (!is_string($mo) && is_a($mo, "BoostedTree") ) {
                $m = $mo;
             } else {
-               $model = $api::retrieve_resource($mo, $api::ONLY_MODEL);
+               $model = $api->retrieve_resource($mo, BigML::ONLY_MODEL);
                $m = new BoostedTree($model->object->model->root, $this->fields, $model->object->model->boosting);
             }
             $this->models[] = clone $m;

--- a/bigml/cluster.php
+++ b/bigml/cluster.php
@@ -60,12 +60,12 @@ class Cluster extends ModelFields {
       }
 
       if (is_string($cluster)) {
-         if (!($api::_checkClusterId($cluster)) ) {
+         if (!($api->_checkClusterId($cluster)) ) {
             error_log("Wrong cluster id");
             return null;
          }
 
-         $cluster = $api::retrieve_resource($cluster, $api::ONLY_MODEL);
+         $cluster = $api->retrieve_resource($cluster, BigML::ONLY_MODEL);
       }
 
       if (property_exists($cluster, "object") && property_exists($cluster->object, "status") && $cluster->object->status->code != BigMLRequest::FINISHED ) {

--- a/bigml/deepnet.php
+++ b/bigml/deepnet.php
@@ -88,7 +88,6 @@ class Deepnet extends ModelFields{
 //             - a deepnet structure
 //             - a deepnet id
 //             - a path to a JSON file containing a deepnet structure
-echo "DEEPNET CONSTRUCTOR -- 1\n";
 
         if ($api == null) {
             $api = new BigML(null, null, null, $storage);
@@ -127,14 +126,10 @@ echo "DEEPNET CONSTRUCTOR -- 1\n";
                 $objective_id = extract_objective($deepnet->objective_fields);
                 $deepnet = $deepnet->deepnet;
 
-echo "EXTRACTED OBJ\n";
-
                 $this->fields = $deepnet->fields;
                 parent::__construct($this->fields, 
                                     $objective_id, 
                                     null, null, true, true);
-
-echo "PARENT CXONSTRUCTED\n";
 
                 $this->regression = ($this->fields->$objective_id->optype ==
                                      NUMERIC);
@@ -145,13 +140,12 @@ echo "PARENT CXONSTRUCTED\n";
                     sort($this->class_names);
                 }
 
-echo "PARENT CXONSTRUCTED -- 1\n";
                 if (array_key_exists("missing_numerics", $deepnet)) {
                     $this->missing_numerics = $deepnet->missing_numerics;
                 } else {
                     $this->missing_numerics = false;
                 }
-echo "PARENT CXONSTRUCTED -- 2\n";
+
                 if (array_key_exists("network", $deepnet)) {
                     $network = $deepnet->network;
                     $this->network = $network;
@@ -160,7 +154,6 @@ echo "PARENT CXONSTRUCTED -- 2\n";
                     } else {
                         $this->networks = [];
                     }
-echo "PARENT CXONSTRUCTED -- 3\n";
                     $this->preprocess = $network->preprocess;
                     if (array_key_exists("optimizer", $network)) {
                         $this->optimizer = $network->optimizer;

--- a/bigml/deepnet.php
+++ b/bigml/deepnet.php
@@ -88,6 +88,7 @@ class Deepnet extends ModelFields{
 //             - a deepnet structure
 //             - a deepnet id
 //             - a path to a JSON file containing a deepnet structure
+echo "DEEPNET CONSTRUCTOR -- 1\n";
 
         if ($api == null) {
             $api = new BigML(null, null, null, $storage);
@@ -97,12 +98,12 @@ class Deepnet extends ModelFields{
             if (file_exists($deepnet)) {
                 $deepnet = json_decode(file_get_contents($deepnet));
                 $this->resource_id = $deepnet["resource"];
-            } elseif (!($api::_checkDeepnetId($deepnet)) ) {
+            } elseif (!($api->_checkDeepnetId($deepnet)) ) {
                 error_log("Wrong deepnet id");
                 return null;
             } else {
-                $deepnet = $api::retrieve_resource($deepnet, 
-                                                   $api::ONLY_MODEL);
+                $deepnet = $api->retrieve_resource($deepnet, 
+                                                   BigML::ONLY_MODEL);
             }
         }
 
@@ -126,10 +127,14 @@ class Deepnet extends ModelFields{
                 $objective_id = extract_objective($deepnet->objective_fields);
                 $deepnet = $deepnet->deepnet;
 
+echo "EXTRACTED OBJ\n";
+
                 $this->fields = $deepnet->fields;
                 parent::__construct($this->fields, 
                                     $objective_id, 
                                     null, null, true, true);
+
+echo "PARENT CXONSTRUCTED\n";
 
                 $this->regression = ($this->fields->$objective_id->optype ==
                                      NUMERIC);
@@ -140,11 +145,13 @@ class Deepnet extends ModelFields{
                     sort($this->class_names);
                 }
 
+echo "PARENT CXONSTRUCTED -- 1\n";
                 if (array_key_exists("missing_numerics", $deepnet)) {
                     $this->missing_numerics = $deepnet->missing_numerics;
                 } else {
                     $this->missing_numerics = false;
                 }
+echo "PARENT CXONSTRUCTED -- 2\n";
                 if (array_key_exists("network", $deepnet)) {
                     $network = $deepnet->network;
                     $this->network = $network;
@@ -153,6 +160,7 @@ class Deepnet extends ModelFields{
                     } else {
                         $this->networks = [];
                     }
+echo "PARENT CXONSTRUCTED -- 3\n";
                     $this->preprocess = $network->preprocess;
                     if (array_key_exists("optimizer", $network)) {
                         $this->optimizer = $network->optimizer;

--- a/bigml/ensemble.php
+++ b/bigml/ensemble.php
@@ -80,8 +80,8 @@ class Ensemble {
             } else if ($model_id instanceof \STDClass) {
                 array_push($models, $model_id);
                $this->objective_id = $model_id->object->objective_field;
-            } else if ($api != null && $api::_checkModelId($model_id)) {
-                $m = $api::get_model($model_id);
+            } else if ($api != null && $api->_checkModelId($model_id)) {
+                $m = $api->get_model($model_id);
 
                if ($m != null) {
                  array_push($models, $m);
@@ -101,11 +101,11 @@ class Ensemble {
          $this->distributions = null;
 
       } else {
-         if (is_string($ensemble) && $api != null && $api::_checkEnsembleId($ensemble)) {
-            $ensemble = $api::get_ensemble($ensemble);
+         if (is_string($ensemble) && $api != null && $api->_checkEnsembleId($ensemble)) {
+            $ensemble = $api->get_ensemble($ensemble);
          }
 
-         if ($ensemble instanceof \STDClass && property_exists($ensemble, "resource") && $api::_checkEnsembleId($ensemble->resource) && $ensemble->object->status->code == 5) {
+         if ($ensemble instanceof \STDClass && property_exists($ensemble, "resource") && $api->_checkEnsembleId($ensemble->resource) && $ensemble->object->status->code == 5) {
 
             $this->boosting = isset($ensemble->object->boosting);
 
@@ -152,7 +152,7 @@ class Ensemble {
             if (!is_string($model_id) && is_a($model_id, "BigML\Model") ) {
               $mo = $model_id;
             } else {
-              $mo = $api::retrieve_resource($model_id, $api::ONLY_MODEL);
+              $mo = $api->retrieve_resource($model_id, BigML::ONLY_MODEL);
             }
 
             $models[] = clone $mo;
@@ -273,7 +273,7 @@ class Ensemble {
          foreach($this->models_splits as $model_split) {
             $models = array();
             foreach($model_split as $model_id) {
-               array_push($models, $api::retrieve_resource($model_id, $api::ONLY_MODEL));
+               array_push($models, $api->retrieve_resource($model_id, BigML::ONLY_MODEL));
             }
 
             $multi_model = new MultiModel($models, $this->api);
@@ -382,7 +382,7 @@ class Ensemble {
               foreach($this->models_splits as $model_split) {
                   $models = array();
                   foreach($model_split as $model_id) {
-                      array_push($models, $api::retrieve_resource($model_id, $api::ONLY_MODEL));
+                      array_push($models, $api->retrieve_resource($model_id, BigML::ONLY_MODEL));
                   }
 
                   $multi_model = new MultiModel($models, $this->api, $this->fields, $this->class_names);

--- a/bigml/logistic.php
+++ b/bigml/logistic.php
@@ -114,11 +114,12 @@ class LogisticRegression extends ModelFields {
          if (file_exists($logistic_regression))
          {
             $logistic_regression = json_decode(file_get_contents($logistic_regression));
-         } elseif (!($api::_checkLogisticRegressionId($logistic_regression)) ) {
+         } elseif (!($api->_checkLogisticRegressionId($logistic_regression)) ) {
             error_log("Wrong logistic regression id");
             return null;
          } else {
-            $logistic_regression = $api::retrieve_resource($logistic_regression, $api::ONLY_MODEL);
+            $logistic_regression = $api->retrieve_resource($logistic_regression,
+                                                           BigML::ONLY_MODEL);
          }
       }
 

--- a/bigml/model.php
+++ b/bigml/model.php
@@ -76,11 +76,11 @@ class Model extends BaseModel{
             if (file_exists($model))
             {
                 $model = json_decode(file_get_contents($model));
-            } else if (!($api::_checkModelId($model)) ) {
+            } else if (!($api->_checkModelId($model)) ) {
                 error_log("Wrong model id");
                 return null;
             } else {
-                $model = $api::retrieve_resource($model, $api::ONLY_MODEL);
+                $model = $api->retrieve_resource($model, BigML::ONLY_MODEL);
             }
         }
 

--- a/bigml/topicmodel.php
+++ b/bigml/topicmodel.php
@@ -121,12 +121,12 @@ class TopicModel extends ModelFields{
       }
 
       if (is_string($topicmodel)) {
-          if (!($api::_checkTopicmodelId($topicmodel)) ) {
+          if (!($api->_checkTopicmodelId($topicmodel)) ) {
               error_log("Wrong topic model id");
               return null;
           }
           
-          $topicmodel = $api::retrieve_resource($topicmodel, $api::ONLY_MODEL);
+          $topicmodel = $api->retrieve_resource($topicmodel, BigML::ONLY_MODEL);
       }
 
       if (property_exists($topicmodel, "object") && property_exists($topicmodel->object, "status") && $topicmodel->object->status->code != BigMLRequest::FINISHED ) {

--- a/bigml/utils.php
+++ b/bigml/utils.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace BigML;
+
+function assign_dir($path) {
+   /*
+     Silently checks the path for existence or creates it.
+     Returns either the path or Null.
+   */
+   if ($path == null || !is_string($path)) {
+      return null;
+   }
+      
+   return check_dir($path);
+}
+
+function check_dir($path) {
+   /*
+     Creates a directory if it doesn't exist
+   */
+   if (file_exists($path)){
+      if (!is_dir($path)) {
+         throw new \Exception("The given path is not a directory");
+      }
+   } elseif (count($path) > 0) {
+      if(!mkdir($path, 0777, true)) {
+         throw new \Exception("Cannot create a directory");
+      }   
+   }
+   return $path;
+}
+
+function maybe_save($resource, $path, $code, $location)
+{
+   /*
+     Builds the resource dict response and saves it if a path is provided.
+     The resource is saved in a local repo json file in the given path
+   */
+   if ($path != null &&  $resource["resource"] != null) {
+      $resource_file_name = $path . DIRECTORY_SEPARATOR . str_replace('/','_',$resource["resource"]);
+
+      $fp = fopen($resource_file_name, 'w');
+      fwrite($fp, json_encode($resource));
+      fclose($fp);
+
+   }
+}
+
+function compareFiles($file_a, $file_b)
+{
+   if (filesize($file_a) == filesize($file_b) && 
+       md5_file($file_a) == md5_file($file_b) ) {
+      return true;
+   }
+   return false;
+}
+
+?>

--- a/tests/test_00_regressions.php
+++ b/tests/test_00_regressions.php
@@ -6,7 +6,6 @@ if (!class_exists('BigML\BigML')) {
     include ('../bigml/bigml.php');
 }
 
-
 if (!class_exists('BigML\BaseModel')) {
     include '../bigml/basemodel.php';
 }
@@ -17,18 +16,17 @@ use BigML\BaseModel;
 
 class BigMLTestCompareRegressions extends PHPUnit_Framework_TestCase
 {
-    protected static $username; # "you_username"
-    protected static $api_key; # "your_api_key"
     protected static $api;
     protected static $project;
 
     public static function setUpBeforeClass() {
-        self::$api =  new BigML(self::$username, self::$api_key, false, "./test-cache");
+        self::$api = new BigML([
+            "storage" => "./test-cache"]);
         ini_set('memory_limit', '512M');
         ini_set('xdebug.max_nesting_level', '300');
-        $test_name=basename(preg_replace('/\.php$/', '', __FILE__));
+        $test_name = basename(preg_replace('/\.php$/', '', __FILE__));
         self::$api->delete_all_project_by_name($test_name);
-        self::$project=self::$api->create_project(array('name'=> $test_name));
+        self::$project = self::$api->create_project(array('name'=> $test_name));
     }
 
     public static function tearDownAfterClass() {

--- a/tests/test_00_regressions.php
+++ b/tests/test_00_regressions.php
@@ -2,6 +2,11 @@
 
 include 'test_utils.php';
 
+if (!class_exists('BigML\BigML')) {
+    include ('../bigml/bigml.php');
+}
+
+
 if (!class_exists('BigML\BaseModel')) {
     include '../bigml/basemodel.php';
 }
@@ -18,7 +23,7 @@ class BigMLTestCompareRegressions extends PHPUnit_Framework_TestCase
     protected static $project;
 
     public static function setUpBeforeClass() {
-        self::$api =  new BigML(self::$username, self::$api_key, BigML::getStorage());
+        self::$api =  new BigML(self::$username, self::$api_key, false, "./test-cache");
         ini_set('memory_limit', '512M');
         ini_set('xdebug.max_nesting_level', '300');
         $test_name=basename(preg_replace('/\.php$/', '', __FILE__));

--- a/tests/test_36_compare_predictions.php
+++ b/tests/test_36_compare_predictions.php
@@ -4,7 +4,7 @@ include 'test_utils.php';
 
 //importing
 if (!class_exists('BigML\BigML')) {
-  include '../bigml/bigml.php';
+   include '../bigml/bigml.php';
 }
 
 if (!class_exists('BigML\Deepnet')) {
@@ -17,158 +17,171 @@ use BigML\Deepnet;
 
 class BigMLTestDeepnets extends PHPUnit_Framework_TestCase
 {
-    protected static $username; # "you_username"
-    protected static $api_key; # "your_api_key"
-    protected static $api;
-    protected static $project;
+   protected static $username; # "you_username"
+   protected static $api_key; # "your_api_key"
+   protected static $api;
+   protected static $project;
 
-    public static function setUpBeforeClass() {
-       self::$api =  new BigML(self::$username, self::$api_key, false);
-       ini_set('memory_limit', '512M');
-       $test_name=basename(preg_replace('/\.php$/', '', __FILE__));
-       self::$api->delete_all_project_by_name($test_name);
-       self::$project=self::$api->create_project(array('name'=> $test_name));
-    }
+   public static function setUpBeforeClass() {
+      self::$api =  new BigML(self::$username, self::$api_key, false);
+      ini_set('memory_limit', '5120M');
+      $test_name=basename(preg_replace('/\.php$/', '', __FILE__));
+      self::$api->delete_all_project_by_name($test_name);
+      self::$project=self::$api->create_project(array('name'=> $test_name));
+   }
 
-    public static function tearDownAfterClass() {
-       self::$api->delete_all_project_by_name(basename(preg_replace('/\.php$/', '', __FILE__)));
-    }
+   public static function tearDownAfterClass() {
+      self::$api->delete_all_project_by_name(basename(preg_replace('/\.php$/', '', __FILE__)));
+   }
 
-    public function test_scenario1() {
+   public function test_scenario1() {
 
-        $data = array(array("filename" => "data/iris.csv", 
-                            "data_input" => array("petal width" => 4),
-                            "objective" => "000004",
-                            "prediction" => "Iris-virginica",
-                            "params" => array()),
-                      array("filename" => "data/iris.csv", 
-                            "data_input" => array("sepal length" => 4.1, 
-                                                  "sepal width" => 2.4),
-                            "objective" => "000004",
-                            "prediction" => "Iris-setosa",
-                            "params" => array()),
-                      array("filename" => "data/iris_missing2.csv", 
-                            "data_input" => array(),
-                            "objective" => "000004",
-                            "prediction" => "Iris-setosa",
-                            "params" => array()),
-                      array("filename" => "data/spam.csv", 
-                            "data_input" => array(),
-                            "objective" => "000000",
-                            "prediction" => "ham",
-                            "params" => array(),
-                            "update_params" => array("fields"=> 
-                                                     array("000001"=> 
-                                                           array("optype"=> "text", 
-                                                                 "term_analysis"=> 
-                                                                      array("case_sensitive" => true, 
-                                                                            "stem_words" => true, 
-                                                                            "use_stopwords" => false, 
-                                                                            "language" => "en"))))),
-                      array("filename" => "data/iris.csv", 
-                            "data_input" => array("sepal length" => 4.1, 
-                                                   "sepal width" => 2.4),
-                            "objective" => "000004",
-                            "prediction" => "Iris-setosa",
-                            "params" => array("search" => true)),
-                      array("filename" => "data/movies.csv", 
-                            "data_input" => array("genres" => "Adventure\$Action", 
-                                                  "timestamp" => 993906291, 
-                                                  "occupation" => "K-12 student"),
-                            "update_params" => array("fields" => array("000007" => 
-                                                                       array("optype"=> "items", 
-                                                                             "item_analysis" => 
-                                                                             array("separator" => 
-                                                                                   "\$")))),
-                            "objective" => "000009",
-                            "prediction" => "4.49741",
-                            "params" => array()),
-                      array("filename" => "data/movies.csv", 
-                            "data_input" => array("genres" => "Adventure\$Action", 
-                                                  "timestamp" => 993906291, 
-                                                  "occupation" => "K-12 student"),
-                             "update_params" => array("fields" => array("000007" => 
-                                                                        array("optype"=> "items", 
-                                                                              "item_analysis" => 
-                                                                              array("separator" => 
-                                                                                    "\$")))),
-                            "objective" => "000009",
-                            "prediction" => "4.49741",
-                            "params" => array("hidden_layers" => [["number_of_nodes" => 32, "activation_function" => "sigmoid"]])),
-                      array("filename" => "data/movies.csv", 
-                            "data_input" => array("genres" => "Adventure\$Action", 
-                                                  "timestamp" => 993906291, 
-                                                  "occupation" => "K-12 student"),
-                            "update_params" => array("fields" => array("000007" => 
-                                                                        array("optype"=> "items", 
-                                                                              "item_analysis" => 
-                                                                              array("separator" => 
-                                                                                    "\$")))),
-                            "objective" => "000009",
-                            "prediction" => "4.49741",
-                            "params" => array("search" => true)));
+      $data2 = array(array("filename" => "data/iris.csv", 
+                          "data_input" => array("petal width" => 4),
+                          "objective" => "000004",
+                          "prediction" => "Iris-virginica",
+                          "params" => array()));
 
-        foreach($data as $item) {
-            print "\n\nSuccessfully comparing predictions for deepnets:\n";
-            print "Given I create a data source uploading a " . $item["filename"] . " file\n";
-            $source = self::$api->create_source($item["filename"], $options=array('name'=>'local_test_source', 'project'=> self::$project->resource));
-            $this->assertEquals(BigMLRequest::HTTP_CREATED, $source->code);
-            $this->assertEquals(1, $source->object->status->code);
+      $data = array(array("filename" => "data/iris.csv", 
+                           "data_input" => array("petal width" => 4),
+                           "objective" => "000004",
+                           "prediction" => "Iris-virginica",
+                           "params" => array()),
+                     array("filename" => "data/iris.csv", 
+                           "data_input" => array("sepal length" => 4.1, 
+                                                 "sepal width" => 2.4),
+                           "objective" => "000004",
+                           "prediction" => "Iris-setosa",
+                           "params" => array()),
+                     array("filename" => "data/iris_missing2.csv", 
+                           "data_input" => array(),
+                           "objective" => "000004",
+                           "prediction" => "Iris-setosa",
+                           "params" => array()),
+                     array("filename" => "data/spam.csv", 
+                           "data_input" => array(),
+                           "objective" => "000000",
+                           "prediction" => "ham",
+                           "params" => array(),
+                           "update_params" => array(
+                              "fields"=> array(
+                                 "000001"=> array(
+                                    "optype"=> "text", 
+                                    "term_analysis"=> array(
+                                       "case_sensitive" => true, 
+                                       "stem_words" => true, 
+                                       "use_stopwords" => false, 
+                                       "language" => "en"))))),
+                     array("filename" => "data/iris.csv", 
+                           "data_input" => array("sepal length" => 4.1, 
+                                                 "sepal width" => 2.4),
+                           "objective" => "000004",
+                           "prediction" => "Iris-setosa",
+                           "params" => array("search" => true)),
+                     array("filename" => "data/movies.csv", 
+                           "data_input" => array(
+                              "genres" => "Adventure\$Action", 
+                              "timestamp" => 993906291, 
+                              "occupation" => "K-12 student"),
+                           "update_params" => array(
+                              "fields" => array(
+                                 "000007" => array(
+                                    "optype"=> "items", 
+                                    "item_analysis" => array(
+                                       "separator" => "\$")))),
+                           "objective" => "000009",
+                           "prediction" => "4.49741",
+                           "params" => array()),
+                     array("filename" => "data/movies.csv", 
+                           "data_input" => array("genres" => "Adventure\$Action", 
+                                                 "timestamp" => 993906291, 
+                                                 "occupation" => "K-12 student"),
+                           "update_params" => array(
+                              "fields" => array(
+                                 "000007" => array(
+                                    "optype"=> "items", 
+                                    "item_analysis" => array(
+                                       "separator" => "\$")))),
+                           "objective" => "000009",
+                           "prediction" => "4.49741",
+                           "params" => array(
+                              "hidden_layers" => [["number_of_nodes" => 32, 
+                                                   "activation_function" => "sigmoid"]])),
+                     array("filename" => "data/movies.csv", 
+                           "data_input" => array("genres" => "Adventure\$Action", 
+                                                 "timestamp" => 993906291, 
+                                                 "occupation" => "K-12 student"),
+                           "update_params" => array(
+                              "fields" => array(
+                                 "000007" => array(
+                                    "optype"=> "items", 
+                                    "item_analysis" => array(
+                                       "separator" => "\$")))),
+                           "objective" => "000009",
+                           "prediction" => "4.49741",
+                           "params" => array("search" => true)));
+      
+      foreach($data as $item) {
+         print "\n\nSuccessfully comparing predictions for deepnets:\n";
+         print "Given I create a data source uploading a " . $item["filename"] . " file\n";
+         $source = self::$api->create_source($item["filename"], $options=array('name'=>'local_test_source', 'project'=> self::$project->resource));
+         $this->assertEquals(BigMLRequest::HTTP_CREATED, $source->code);
+         $this->assertEquals(1, $source->object->status->code);
 
-            print "And I wait until the source is ready\n";
-            $resource = self::$api->_check_resource($source->resource, null, 3000, 30);
-            $this->assertEquals(BigMLRequest::FINISHED, $resource["status"]);
+         print "And I wait until the source is ready\n";
+         $resource = self::$api->_check_resource($source->resource, null, 3000, 30);
+         $this->assertEquals(BigMLRequest::FINISHED, $resource["status"]);
 
-            if (isset($item["update_params"])) {
-                print "And I update the source\n";
-                $source = self::$api->update_source($source->resource, $item["update_params"], 3000, 30);
-            }
+         if (isset($item["update_params"])) {
+            print "And I update the source\n";
+            $source = self::$api->update_source($source->resource, $item["update_params"], 3000, 30);
+         }
 
-            print "And I create a dataset\n";
-            $dataset = self::$api->create_dataset($source->resource);
-            $this->assertEquals(BigMLRequest::HTTP_CREATED, $dataset->code);
-            $this->assertEquals(BigMLRequest::QUEUED, $dataset->object->status->code);
+         print "And I create a dataset\n";
+         $dataset = self::$api->create_dataset($source->resource);
+         $this->assertEquals(BigMLRequest::HTTP_CREATED, $dataset->code);
+         $this->assertEquals(BigMLRequest::QUEUED, $dataset->object->status->code);
 
-            print "And I wait until the dataset is ready\n";
-            $resource = self::$api->_check_resource($dataset->resource, null, 3000, 30);
-            $this->assertEquals(BigMLRequest::FINISHED, $resource["status"]);
+         print "And I wait until the dataset is ready\n";
+         $resource = self::$api->_check_resource($dataset->resource, null, 3000, 30);
+         $this->assertEquals(BigMLRequest::FINISHED, $resource["status"]);
 
-            print "And I create a deepnet with objective " . $item["objective"] .
-                  " and " . json_encode($item["params"]) . "\n";
-            $deepnet = self::$api->create_deepnet($dataset->resource, $item["params"]);
-            $this->assertEquals(BigMLRequest::HTTP_CREATED, $deepnet->code);
+         print "And I create a deepnet with objective " . $item["objective"] .
+                                                        " and " . json_encode($item["params"]) . "\n";
+         $deepnet = self::$api->create_deepnet($dataset->resource, $item["params"]);
+         $this->assertEquals(BigMLRequest::HTTP_CREATED, $deepnet->code);
 
-            print "And I wait until the deepnet is ready\n";
-            $resource = self::$api->_check_resource($deepnet->resource, null, 3000, 500);
-            $this->assertEquals(BigMLRequest::FINISHED, $resource["status"]);
+         print "And I wait until the deepnet is ready\n";
+         $resource = self::$api->_check_resource($deepnet->resource, null, 3000, 500);
+         $this->assertEquals(BigMLRequest::FINISHED, $resource["status"]);
 
-            print "And I create a local deepnet\n";
-            $local_deepnet = new Deepnet($deepnet->resource);
+         print "And I create a local deepnet\n";
+         $local_deepnet = new Deepnet($deepnet->resource);
 
-            print "And I create a deepnet prediction\n";
-            $prediction = self::$api->create_prediction($deepnet->resource, $item["data_input"]);
+         print "And I create a deepnet prediction\n";
+         $prediction = self::$api->create_prediction($deepnet->resource, $item["data_input"]);
 
-            print "The prediction is ";
-            $prediction_value = $prediction->object->prediction->$item["objective"];
-            print_r($prediction_value);
+         print "The prediction is ";
+         $prediction_value = $prediction->object->prediction->$item["objective"];
+         print_r($prediction_value);
             
 
-            print "\nAnd I create a local deepnet prediction\n";
-            $local_prediction = $local_deepnet->predict($item["data_input"]);
+         print "\nAnd I create a local deepnet prediction\n";
+         $local_prediction = $local_deepnet->predict($item["data_input"]);
 
-            if (is_array($local_prediction["prediction"])) {
-                $local_prediction = $local_prediction["prediction"];
-            } else {
-                $prediction_value = round($prediction_value, 5);
-                $local_prediction = round($local_prediction, 5);
-            }
+         if (is_array($local_prediction["prediction"])) {
+            $local_prediction = $local_prediction["prediction"];
+         } else {
+            $prediction_value = round($prediction_value, 5);
+            $local_prediction = round($local_prediction, 5);
+         }
 
-            print "The local prediction is ";
-            print_r($local_prediction);
-            $this->assertEquals($prediction_value, 
-                                $local_prediction);
+         print "The local prediction is ";
+         print_r($local_prediction);
+         $this->assertEquals($prediction_value, 
+                             $local_prediction);
 
-        }
-    }
+      }
+   }
 }
 ?>

--- a/tests/test_38_organizations.php
+++ b/tests/test_38_organizations.php
@@ -30,6 +30,7 @@ class BigMLTestOrganizations extends PHPUnit_Framework_TestCase
        self::$test_name = basename(preg_replace('/\.php$/', '', __FILE__));
        self::$api_org->delete_all_project_by_name(self::$test_name);
        self::$project = self::$api_org->create_project(array('name'=> self::$test_name));
+       self::assertEquals($org, self::$project->object->organization);
 
        self::$api = new BigML(["project" => self::$project->resource]);
     }
@@ -49,6 +50,7 @@ class BigMLTestOrganizations extends PHPUnit_Framework_TestCase
         );
         
         foreach($data as $item) {
+
            print "\nSuccessfully creating a prediction:\n";
            print "Given I create a data source uploading a ". $item["filename"]. " file\n";
            $source = self::$api->create_source($item["filename"],
@@ -56,6 +58,7 @@ class BigMLTestOrganizations extends PHPUnit_Framework_TestCase
                                                   'name'=>'local_test_source'));
            $this->assertEquals(BigMLRequest::HTTP_CREATED, $source->code);
            $this->assertEquals(1, $source->object->status->code);
+           $this->assertEquals(self::$project->resource, $source->object->project);
            
            print "And I wait until the source is ready\n";
            $resource = self::$api->_check_resource($source->resource, null, 3000, 30);

--- a/tests/test_38_organizations.php
+++ b/tests/test_38_organizations.php
@@ -1,0 +1,92 @@
+<?php
+
+include('test_utils.php');
+
+if (!class_exists('bigml')) {
+   include '../bigml/bigml.php';
+}
+
+use BigML\BigML;
+use BigML\BigMLRequest;
+
+class BigMLTestOrganizations extends PHPUnit_Framework_TestCase
+{
+    protected static $api;
+    protected static $api_org;
+    protected static $data_localfile = './data/iris.csv';
+    protected static $project;
+    protected static $test_name;
+
+    public static function setUpBeforeClass() {
+
+       $org = getenv("BIGML_ORGANIZATION");
+       if ($org == null) {
+          throw new Exception("You need to define env variable " .
+                              "BIGML_ORGANIZATION to run this test.");
+       }
+
+       self::$api_org =  new BigML(["organization" => $org]);
+       ini_set('memory_limit', '512M');
+       self::$test_name = basename(preg_replace('/\.php$/', '', __FILE__));
+       self::$api_org->delete_all_project_by_name(self::$test_name);
+       self::$project = self::$api_org->create_project(array('name'=> self::$test_name));
+
+       self::$api = new BigML(["project" => self::$project->resource]);
+    }
+
+    public static function tearDownAfterClass() {
+       self::$api_org->delete_all_project_by_name(self::$test_name);
+    }
+
+    /*  Scenario: Successfully creating a prediction: */
+
+    public function test_scenario1() {
+
+        $data = array(array("filename"=>  self::$data_localfile,
+                            "data_input" => array('petal width'=> 0.5),
+                            "objective" => "000004",
+                            "prediction" => "Iris-setosa")
+        );
+        
+        foreach($data as $item) {
+           print "\nSuccessfully creating a prediction:\n";
+           print "Given I create a data source uploading a ". $item["filename"]. " file\n";
+           $source = self::$api->create_source($item["filename"],
+                                               $options = array(
+                                                  'name'=>'local_test_source'));
+           $this->assertEquals(BigMLRequest::HTTP_CREATED, $source->code);
+           $this->assertEquals(1, $source->object->status->code);
+           
+           print "And I wait until the source is ready\n";
+           $resource = self::$api->_check_resource($source->resource, null, 3000, 30);
+           $this->assertEquals(BigMLRequest::FINISHED, $resource["status"]);
+           
+           print "And I create dataset with local source\n";
+           $dataset = self::$api->create_dataset($source->resource);
+           $this->assertEquals(BigMLRequest::HTTP_CREATED, $dataset->code);
+           $this->assertEquals(BigMLRequest::QUEUED, $dataset->object->status->code);
+           
+           print "And I wait until the dataset is ready\n";
+           $resource = self::$api->_check_resource($dataset->resource, null, 3000, 30);
+           $this->assertEquals(BigMLRequest::FINISHED, $resource["status"]);
+           
+           print "And I create model\n";
+           $model = self::$api->create_model($dataset->resource);
+           $this->assertEquals(BigMLRequest::HTTP_CREATED, $model->code);
+           
+           print "And I wait until the model is ready\n";
+           $resource = self::$api->_check_resource($model->resource, null, 3000, 30);
+           $this->assertEquals(BigMLRequest::FINISHED, $resource["status"]);
+           
+           print "When I create a prediction for " . json_encode($item["data_input"]) . "\n";
+           $prediction = self::$api->create_prediction($model, $item["data_input"]);
+           $this->assertEquals(BigMLRequest::HTTP_CREATED, $prediction->code);
+           
+           print "Then the prediction for " . $item["objective"] . " is " . $item["prediction"];
+           
+           $this->assertEquals($item["prediction"],
+                               $prediction->object->prediction->{$item["objective"]});
+           
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for organizations.

This required a structural change in the BigML class to replace all static methods with instance methods, and the ensueing refactoring.

This change breaks backwards compatibility, meaning that if users accessed BigML methods as static methods instead of through a BigML instance, their code will not work anymore (refactoring is trivial though).

Additionally, the old BigML class constructor has been (sort of) deprecated in favour of a new one allowing the use of named parameters.