### PR TITLE
Fixed undefined array key

### DIFF
--- a/bigml/bigml.php
+++ b/bigml/bigml.php
@@ -3300,7 +3300,7 @@ final class BigMLRequest {
          $headers = explode("\n", $headers);
          foreach($headers as $header) {
             if (stripos($header, 'Location:') !== false) {
-               $cad = explode("Location:", $header);
+               $cad = explode(": ", $header);
                $this->response["location"] =trim($cad[1]);
                $location = $this->response["location"];
                break;


### PR DESCRIPTION
Fixes undefined array key error.

I was unable to get a successful response when using the following code:

```
$api = new \BigML\BigML([
    'username' => '*****',
    'apiKey' => ‘*****’,
    'project' => 'project/*****',
]);

$prediction = $api->create_prediction('model/*****', ['000001' => 3]);

dd($prediction);

{#1507 
  +"code": 500
  +"resource": null
  +"location": null
  +"object": null
  +"error": {#1509
    +"status": {#1508
      +"code": 500
      +"message": "retrieved"
    }
  }
}
```

Output the exception within the bigml.php file:

<img width="452" alt="PastedGraphic-1" src="https://github.com/bigmlcom/bigml-php/assets/18044230/e1573458-ee99-468d-adbe-2738a35c1af2">
